### PR TITLE
docs(store): fix inline comments spelling in AuthProvider

### DIFF
--- a/src/store/auth/AuthProvider.tsx
+++ b/src/store/auth/AuthProvider.tsx
@@ -70,7 +70,7 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
         })
 
         // if the unauthenticated user is trying to navigate to a
-        // protected app routue, redirect them to the login page.
+        // protected app route, redirect them to the login page.
         if (!matchProtectedRoute && location.pathname !== Routes.AUTH_LOGOUT) {
           // navigate(Routes.DASHBOARD)
         }
@@ -80,7 +80,7 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
           error: error as Error,
         })
         // if the unauthenticated user is trying to navigate to a
-        // protected app routue, redirect them to the login page.
+        // protected app route, redirect them to the login page.
         if (matchProtectedRoute) {
           // navigate(Routes.AUTH_LOGIN)
         }


### PR DESCRIPTION
## Summary

Fixes a minor misspelling in inline comments inside of `src/store/auth/AuthProvider.tsx`

### Added

_n/a_

### Changed

_n/a_

### Deprecated

_n/a_

### Removed

_n/a_

### Fixed

- fixes spelling error inline comments in `src/store/auth/AuthProvider.tsx`.

## How to test

_n/a_
