### PR TITLE
fix(store): uncomment auth-state auto-nav in AuthProvider

### DIFF
--- a/src/store/auth/AuthProvider.tsx
+++ b/src/store/auth/AuthProvider.tsx
@@ -70,9 +70,9 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
         })
 
         // if the unauthenticated user is trying to navigate to a
-        // protected app routue, redirect them to the login page.
+        // protected app route, redirect them to the login page.
         if (!matchProtectedRoute && location.pathname !== Routes.AUTH_LOGOUT) {
-          // navigate(Routes.DASHBOARD)
+          navigate(Routes.DASHBOARD)
         }
       } catch (error) {
         dispatch({
@@ -80,9 +80,9 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
           error: error as Error,
         })
         // if the unauthenticated user is trying to navigate to a
-        // protected app routue, redirect them to the login page.
+        // protected app route, redirect them to the login page.
         if (matchProtectedRoute) {
-          // navigate(Routes.AUTH_LOGIN)
+          navigate(Routes.AUTH_LOGIN)
         }
       }
     }


### PR DESCRIPTION
## Summary

Uncomments the auth-state-based automatic navigation inside of the `AuthProvider` to re-enable forcing the user to navigate...
- to the Dashboard if the user is already authenticated but goes to the login page, or
- to the login page if the user is not authenticated but goes to the dashboard (or any other child routes that require authentication -- e.g. when `authLoader` throws in the data loader function for the protected routes)

### Added

_n/a_

### Changed

- re-enables forced navigation based on auth-state in `src/store/auth/AuthProvider.tsx`.

### Deprecated

_n/a_

### Removed

_n/a_

### Fixed

- fixes spelling error inline comments in `src/store/auth/AuthProvider.tsx`.

## How to test

- ⚠️ untested, *DO NOT MERGE*

## Related Issues

- #11 