### PR TITLE
ci(dependabot): ignore major version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,12 @@ updates:
       interval: 'daily'
       time: '08:00'
       timezone: 'America/New_York'
+    reviewers:
+      - 'sbolel'
     labels:
       - 'dependencies'
     rebase-strategy: 'auto'
-    reviewers:
-      - 'sbolel'
     versioning-strategy: increase
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary

This PR updates the Dependabot configuration to exclude major version upgrades, ensuring that only minor and patch updates are automatically applied. This change addresses the potential risk of introducing breaking changes through automatic updates.

### Added

- None

### Changed

- **Dependabot Configuration**: Updated to exclude major version updates by adding an `ignore` section specifying that major version updates should be ignored.

### Deprecated

- None

### Removed

- None

### Fixed

- None

## How to test

1. **Dependabot Configuration**:
   - Review the updated `.github/dependabot.yml` file to ensure that the `ignore` section correctly specifies the exclusion of major version updates.
   - Verify that the configuration includes the appropriate settings for minor and patch updates.

2. **Dependabot Behavior**:
   - Monitor Dependabot pull requests to ensure that only minor and patch updates are created.
   - Confirm that major version updates are not automatically applied.

### Issue

- Closes #36 