### PR TITLE
ci(github): change workflow to trigger on pull_request_target

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -5,7 +5,7 @@
 # minor upgrade, it enables auto-merge for the Dependabot PR using the GitHub CLI.
 name: Dependabot auto-merge
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Changes the dependabot automerge workflow to trigger on `pull_request_target` instead of `pull_request`

### Added

<!-- List new features or components. Include a screenshot for new visual elements. -->

### Changed

- Changed `on: pull_request` to `on: pull_request_target` in .github/dependabot-automerge.yml`

### Deprecated

<!-- List once-stable features or components to be deprecated in this PR. -->

### Removed

<!-- List deprecated features or components removed in this PR. -->

### Fixed

<!-- List any bug fixes. -->

## How to test

<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->
