### PR TITLE
build(deps): dedupe dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,17 +2171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5, @babel/code-frame@npm:^7.24.2":
-  version: 7.24.2
-  resolution: "@babel/code-frame@npm:7.24.2"
-  dependencies:
-    "@babel/highlight": "npm:^7.24.2"
-    picocolors: "npm:^1.0.0"
-  checksum: 10/7db8f5b36ffa3f47a37f58f61e3d130b9ecad21961f3eede7e2a4ac2c7e4a5efb6e9d03a810c669bc986096831b6c0dfc2c3082673d93351b82359c1b03e0590
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.24.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/code-frame@npm:7.24.7"
   dependencies:
@@ -2191,44 +2181,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.23.3, @babel/compat-data@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/compat-data@npm:7.23.5"
-  checksum: 10/088f14f646ecbddd5ef89f120a60a1b3389a50a9705d44603dca77662707d0175a5e0e0da3943c3298f1907a4ab871468656fbbf74bb7842cd8b0686b2c19736
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.24.8":
+"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.23.3, @babel/compat-data@npm:^7.23.5, @babel/compat-data@npm:^7.24.8":
   version: 7.24.9
   resolution: "@babel/compat-data@npm:7.24.9"
   checksum: 10/fcdbf3dd978305880f06ae20a23f4f68a8eddbe64fc5d2fbc98dfe4cdf15c174cff41e3a8eb9d935f9f3a68d3a23fa432044082ee9768a2ed4b15f769b8f6853
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.18.9, @babel/core@npm:^7.20.12, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2":
-  version: 7.24.5
-  resolution: "@babel/core@npm:7.24.5"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.2.0"
-    "@babel/code-frame": "npm:^7.24.2"
-    "@babel/generator": "npm:^7.24.5"
-    "@babel/helper-compilation-targets": "npm:^7.23.6"
-    "@babel/helper-module-transforms": "npm:^7.24.5"
-    "@babel/helpers": "npm:^7.24.5"
-    "@babel/parser": "npm:^7.24.5"
-    "@babel/template": "npm:^7.24.0"
-    "@babel/traverse": "npm:^7.24.5"
-    "@babel/types": "npm:^7.24.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10/b0d02c51f39cc4c6f8fcaab7052d17dea63aab36d7e2567bfbad074e5a027df737ebcaf3029c3a659bc719bbac806311c2e8786be1d686abd093c48a6068395c
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.24.9":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.18.9, @babel/core@npm:^7.20.12, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2, @babel/core@npm:^7.24.9":
   version: 7.24.9
   resolution: "@babel/core@npm:7.24.9"
   dependencies:
@@ -2251,19 +2211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.0, @babel/generator@npm:^7.24.5, @babel/generator@npm:^7.7.2":
-  version: 7.24.5
-  resolution: "@babel/generator@npm:7.24.5"
-  dependencies:
-    "@babel/types": "npm:^7.24.5"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^2.5.1"
-  checksum: 10/7a3782f1d2f824025a538444a0fce44f5b30a7b013984279561bcb3450eec91a41526533fd0b25b1a6fde627bebd0e645c0ea2aa907cc15c7f3da2d9eb71f069
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.24.8, @babel/generator@npm:^7.24.9":
+"@babel/generator@npm:^7.23.0, @babel/generator@npm:^7.24.8, @babel/generator@npm:^7.24.9, @babel/generator@npm:^7.7.2":
   version: 7.24.10
   resolution: "@babel/generator@npm:7.24.10"
   dependencies:
@@ -2293,20 +2241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.22.15, @babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.23.6":
-  version: 7.23.6
-  resolution: "@babel/helper-compilation-targets@npm:7.23.6"
-  dependencies:
-    "@babel/compat-data": "npm:^7.23.5"
-    "@babel/helper-validator-option": "npm:^7.23.5"
-    browserslist: "npm:^4.22.2"
-    lru-cache: "npm:^5.1.1"
-    semver: "npm:^6.3.1"
-  checksum: 10/05595cd73087ddcd81b82d2f3297aac0c0422858dfdded43d304786cf680ec33e846e2317e6992d2c964ee61d93945cbf1fa8ec80b55aee5bfb159227fb02cb9
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.24.8":
+"@babel/helper-compilation-targets@npm:^7.22.15, @babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.23.6, @babel/helper-compilation-targets@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-compilation-targets@npm:7.24.8"
   dependencies:
@@ -2366,14 +2301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-environment-visitor@npm:^7.22.20":
-  version: 7.22.20
-  resolution: "@babel/helper-environment-visitor@npm:7.22.20"
-  checksum: 10/d80ee98ff66f41e233f36ca1921774c37e88a803b2f7dca3db7c057a5fea0473804db9fb6729e5dbfd07f4bed722d60f7852035c2c739382e84c335661590b69
-  languageName: node
-  linkType: hard
-
-"@babel/helper-environment-visitor@npm:^7.24.7":
+"@babel/helper-environment-visitor@npm:^7.22.20, @babel/helper-environment-visitor@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-environment-visitor@npm:7.24.7"
   dependencies:
@@ -2382,17 +2310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.22.5, @babel/helper-function-name@npm:^7.23.0":
-  version: 7.23.0
-  resolution: "@babel/helper-function-name@npm:7.23.0"
-  dependencies:
-    "@babel/template": "npm:^7.22.15"
-    "@babel/types": "npm:^7.23.0"
-  checksum: 10/7b2ae024cd7a09f19817daf99e0153b3bf2bc4ab344e197e8d13623d5e36117ed0b110914bc248faa64e8ccd3e97971ec7b41cc6fd6163a2b980220c58dcdf6d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.24.7":
+"@babel/helper-function-name@npm:^7.22.5, @babel/helper-function-name@npm:^7.23.0, @babel/helper-function-name@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-function-name@npm:7.24.7"
   dependencies:
@@ -2402,16 +2320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-hoist-variables@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
-  dependencies:
-    "@babel/types": "npm:^7.22.5"
-  checksum: 10/394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
-  languageName: node
-  linkType: hard
-
-"@babel/helper-hoist-variables@npm:^7.24.7":
+"@babel/helper-hoist-variables@npm:^7.22.5, @babel/helper-hoist-variables@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-hoist-variables@npm:7.24.7"
   dependencies:
@@ -2429,16 +2338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.24.3":
-  version: 7.24.3
-  resolution: "@babel/helper-module-imports@npm:7.24.3"
-  dependencies:
-    "@babel/types": "npm:^7.24.0"
-  checksum: 10/42fe124130b78eeb4bb6af8c094aa749712be0f4606f46716ce74bc18a5ea91c918c547c8bb2307a2e4b33f163e4ad2cb6a7b45f80448e624eae45b597ea3499
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.24.7":
+"@babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-module-imports@npm:7.24.7"
   dependencies:
@@ -2448,22 +2348,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.23.3, @babel/helper-module-transforms@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/helper-module-transforms@npm:7.24.5"
-  dependencies:
-    "@babel/helper-environment-visitor": "npm:^7.22.20"
-    "@babel/helper-module-imports": "npm:^7.24.3"
-    "@babel/helper-simple-access": "npm:^7.24.5"
-    "@babel/helper-split-export-declaration": "npm:^7.24.5"
-    "@babel/helper-validator-identifier": "npm:^7.24.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/1a91e8abc2f427f8273ce3b99ef7b9c013eb3628221428553e0d4bc9c6db2e73bc4fc1b8535bd258544936accab9380e0d095f2449f913cad650ddee744b2124
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.24.9":
+"@babel/helper-module-transforms@npm:^7.23.3, @babel/helper-module-transforms@npm:^7.24.9":
   version: 7.24.9
   resolution: "@babel/helper-module-transforms@npm:7.24.9"
   dependencies:
@@ -2520,16 +2405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@npm:^7.22.5, @babel/helper-simple-access@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/helper-simple-access@npm:7.24.5"
-  dependencies:
-    "@babel/types": "npm:^7.24.5"
-  checksum: 10/db8768a16592faa1bde9061cac3d903bdbb2ddb2a7e9fb73c5904daee1f1b1dc69ba4d249dc22c45885c0d4b54fd0356ee78e6d67a9a90330c7dd37e6cd3acff
-  languageName: node
-  linkType: hard
-
-"@babel/helper-simple-access@npm:^7.24.7":
+"@babel/helper-simple-access@npm:^7.22.5, @babel/helper-simple-access@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-simple-access@npm:7.24.7"
   dependencies:
@@ -2548,28 +2424,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.22.6, @babel/helper-split-export-declaration@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/helper-split-export-declaration@npm:7.24.5"
-  dependencies:
-    "@babel/types": "npm:^7.24.5"
-  checksum: 10/84777b6304ef0fe6501038985b61aaa118082688aa54eca8265f14f3ae2e01adf137e9111f4eb9870e0e9bc23901e0b8859bb2a9e4362ddf89d05e1c409c2422
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.24.7":
+"@babel/helper-split-export-declaration@npm:^7.22.6, @babel/helper-split-export-declaration@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-split-export-declaration@npm:7.24.7"
   dependencies:
     "@babel/types": "npm:^7.24.7"
   checksum: 10/ff04a3071603c87de0d6ee2540b7291ab36305b329bd047cdbb6cbd7db335a12f9a77af1cf708779f75f13c4d9af46093c00b34432e50b2411872c658d1a2e5e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.24.1":
-  version: 7.24.1
-  resolution: "@babel/helper-string-parser@npm:7.24.1"
-  checksum: 10/04c0ede77b908b43e6124753b48bc485528112a9335f0a21a226bff1ace75bb6e64fab24c85cb4b1610ef3494dacd1cb807caeb6b79a7b36c43d48c289b35949
   languageName: node
   linkType: hard
 
@@ -2580,28 +2440,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/helper-validator-identifier@npm:7.24.5"
-  checksum: 10/38aaf6a64a0ea2e84766165b461deda3c24fd2173dff18419a2cc9e1ea1d3e709039aee94db29433a07011492717c80900a5eb564cdca7d137757c3c69e26898
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.24.7":
+"@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 10/86875063f57361471b531dbc2ea10bbf5406e12b06d249b03827d361db4cad2388c6f00936bcd9dc86479f7e2c69ea21412c2228d4b3672588b754b70a449d4b
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/helper-validator-option@npm:7.23.5"
-  checksum: 10/537cde2330a8aede223552510e8a13e9c1c8798afee3757995a7d4acae564124fe2bf7e7c3d90d62d3657434a74340a274b3b3b1c6f17e9a2be1f48af29cb09e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.24.8":
+"@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.23.5, @babel/helper-validator-option@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-validator-option@npm:7.24.8"
   checksum: 10/a52442dfa74be6719c0608fee3225bd0493c4057459f3014681ea1a4643cd38b68ff477fe867c4b356da7330d085f247f0724d300582fa4ab9a02efaf34d107c
@@ -2619,17 +2465,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/helpers@npm:7.24.5"
-  dependencies:
-    "@babel/template": "npm:^7.24.0"
-    "@babel/traverse": "npm:^7.24.5"
-    "@babel/types": "npm:^7.24.5"
-  checksum: 10/efd74325823c70a32aa9f5e263c8eb0a1f729f5e9ea168e3226fa92a10b1702593b76034812e9f7b560d6447f9cd446bad231d7086af842129c6596306300094
-  languageName: node
-  linkType: hard
-
 "@babel/helpers@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helpers@npm:7.24.8"
@@ -2637,18 +2472,6 @@ __metadata:
     "@babel/template": "npm:^7.24.7"
     "@babel/types": "npm:^7.24.8"
   checksum: 10/61c08a2baa87382a87c7110e9b5574c782603e247b7e6267769ee0e8b7b54b70ff05f16466f05bb318622b7ac28e79b449edff565abf5adcb1adb1b0f42fee9c
-  languageName: node
-  linkType: hard
-
-"@babel/highlight@npm:^7.24.2":
-  version: 7.24.5
-  resolution: "@babel/highlight@npm:7.24.5"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.24.5"
-    chalk: "npm:^2.4.2"
-    js-tokens: "npm:^4.0.0"
-    picocolors: "npm:^1.0.0"
-  checksum: 10/afde0403154ad69ecd58a98903058e776760444bf4d0363fb740a8596bc6278b72c5226637c4f6b3674d70acb1665207fe2fcecfe93a74f2f4ab033e89fd7e8c
   languageName: node
   linkType: hard
 
@@ -2664,16 +2487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.0, @babel/parser@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/parser@npm:7.24.5"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/f5ed1c5fd4b0045a364fb906f54fd30e2fff93a45069068b6d80d3ab2b64f5569c90fb41d39aff80fb7e925ca4d44917965a76776a3ca11924ec1fae3be5d1ea
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.24.7, @babel/parser@npm:^7.24.8":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/parser@npm:7.24.8"
   bin:
@@ -3760,18 +3574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.20.7, @babel/template@npm:^7.22.15, @babel/template@npm:^7.24.0, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.4":
-  version: 7.24.0
-  resolution: "@babel/template@npm:7.24.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.23.5"
-    "@babel/parser": "npm:^7.24.0"
-    "@babel/types": "npm:^7.24.0"
-  checksum: 10/8c538338c7de8fac8ada691a5a812bdcbd60bd4a4eb5adae2cc9ee19773e8fb1a724312a00af9e1ce49056ffd3c3475e7287b5668cf6360bfb3f8ac827a06ffe
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.24.7":
+"@babel/template@npm:^7.20.7, @babel/template@npm:^7.22.15, @babel/template@npm:^7.24.7, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.4":
   version: 7.24.7
   resolution: "@babel/template@npm:7.24.7"
   dependencies:
@@ -3782,25 +3585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.24.5":
-  version: 7.24.5
-  resolution: "@babel/traverse@npm:7.24.5"
-  dependencies:
-    "@babel/code-frame": "npm:^7.24.2"
-    "@babel/generator": "npm:^7.24.5"
-    "@babel/helper-environment-visitor": "npm:^7.22.20"
-    "@babel/helper-function-name": "npm:^7.23.0"
-    "@babel/helper-hoist-variables": "npm:^7.22.5"
-    "@babel/helper-split-export-declaration": "npm:^7.24.5"
-    "@babel/parser": "npm:^7.24.5"
-    "@babel/types": "npm:^7.24.5"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10/e237de56e0c30795293fdb6f2cb09a75e6230836e3dc67dc4fa21781eb4d5842996bf3af95bc57ac5c7e6e97d06446f14732d0952eb57d5d9643de7c4f95bee6
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8":
+"@babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/traverse@npm:7.24.8"
   dependencies:
@@ -3818,18 +3603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.24.5
-  resolution: "@babel/types@npm:7.24.5"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.24.1"
-    "@babel/helper-validator-identifier": "npm:^7.24.5"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/259e7512476ae64830e73f2addf143159232bcbf0eba6a6a27cab25a960cd353a11c826eb54185fdf7d8d9865922cbcd6522149e9ec55b967131193f9c9111a1
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.24.9":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.24.9, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.24.9
   resolution: "@babel/types@npm:7.24.9"
   dependencies:
@@ -9582,21 +9356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.22.2":
-  version: 4.22.3
-  resolution: "browserslist@npm:4.22.3"
-  dependencies:
-    caniuse-lite: "npm:^1.0.30001580"
-    electron-to-chromium: "npm:^1.4.648"
-    node-releases: "npm:^2.0.14"
-    update-browserslist-db: "npm:^1.0.13"
-  bin:
-    browserslist: cli.js
-  checksum: 10/d46a906c79dfe95d9702c020afbe5b7b4dbe2019b85432e7a020326adff27e63e3c0a52dc8d4e73247060bbe2c13f000714741903cf96a16baae9c216dc74c75
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.23.1":
+"browserslist@npm:^4.22.2, browserslist@npm:^4.23.1":
   version: 4.23.2
   resolution: "browserslist@npm:4.23.2"
   dependencies:
@@ -9776,13 +9536,6 @@ __metadata:
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001580":
-  version: 1.0.30001581
-  resolution: "caniuse-lite@npm:1.0.30001581"
-  checksum: 10/c2d049514e6af5e9a9b23646b7828191f4c2d3ef1ad999d3efe02683d56d0067d616e2eadb055fe5477f870b22e7252dc09834f95007c95f310d8eca30cfa912
   languageName: node
   linkType: hard
 
@@ -11016,13 +10769,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.648":
-  version: 1.4.650
-  resolution: "electron-to-chromium@npm:1.4.650"
-  checksum: 10/5e57767ff25cdc1175203ab41d9fe141916651b239f90b2b531d48fc21cd98a602e44b443ac5e21bab3ffac2c8da61513f3e459e44621aa5999ad12a87e62965
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.4.820":
   version: 1.4.829
   resolution: "electron-to-chromium@npm:1.4.829"
@@ -11463,14 +11209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "escalade@npm:3.1.1"
-  checksum: 10/afa618e73362576b63f6ca83c975456621095a1ed42ff068174e3f5cea48afc422814dda548c96e6ebb5333e7265140c7292abcc81bbd6ccb1757d50d3a4e182
-  languageName: node
-  linkType: hard
-
-"escalade@npm:^3.1.2":
+"escalade@npm:^3.1.1, escalade@npm:^3.1.2":
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
   checksum: 10/a1e07fea2f15663c30e40b9193d658397846ffe28ce0a3e4da0d8e485fedfeca228ab846aee101a05015829adf39f9934ff45b2a3fca47bed37a29646bd05cd3
@@ -16917,14 +16656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "picocolors@npm:1.0.0"
-  checksum: 10/a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.0.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
   checksum: 10/fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
@@ -20370,20 +20102,6 @@ __metadata:
   version: 4.0.0
   resolution: "untildify@npm:4.0.0"
   checksum: 10/39ced9c418a74f73f0a56e1ba4634b4d959422dff61f4c72a8e39f60b99380c1b45ed776fbaa0a4101b157e4310d873ad7d114e8534ca02609b4916bb4187fb9
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.0.13":
-  version: 1.0.13
-  resolution: "update-browserslist-db@npm:1.0.13"
-  dependencies:
-    escalade: "npm:^3.1.1"
-    picocolors: "npm:^1.0.0"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 10/9074b4ef34d2ed931f27d390aafdd391ee7c45ad83c508e8fed6aaae1eb68f81999a768ed8525c6f88d4001a4fbf1b8c0268f099d0e8e72088ec5945ac796acf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Ran `yarn dedupe` to optimize and consolidate dependencies, reducing duplicate packages.

### Added

- None

### Changed

- Dependencies have been deduplicated to reduce redundancy and improve performance.

  Result:
  ```
  No new packages added to the project, but 27 were removed (- 2.48 MiB).
  ```
  <details>
  <summary>Click here to view details of deduplicated packages</summary>

  ```
  ➤ YN0000: ┌ Deduplication step
  ➤ YN0000: │ @babel/compat-data@npm:^7.22.6 can be deduped from @babel/compat-data@npm:7.23.5 to @babel/compat-data@npm:7.24.9
  ➤ YN0000: │ @babel/compat-data@npm:^7.23.3 can be deduped from @babel/compat-data@npm:7.23.5 to @babel/compat-data@npm:7.24.9
  ➤ YN0000: │ @babel/compat-data@npm:^7.23.5 can be deduped from @babel/compat-data@npm:7.23.5 to @babel/compat-data@npm:7.24.9
  ➤ YN0000: │ @babel/helper-string-parser@npm:^7.24.1 can be deduped from @babel/helper-string-parser@npm:7.24.1 to @babel/helper-string-parser@npm:7.24.8
  ➤ YN0000: │ @babel/helper-validator-identifier@npm:^7.22.20 can be deduped from @babel/helper-validator-identifier@npm:7.24.5 to @babel/helper-validator-identifier@npm:7.24.7
  ➤ YN0000: │ @babel/helper-validator-identifier@npm:^7.24.5 can be deduped from @babel/helper-validator-identifier@npm:7.24.5 to @babel/helper-validator-identifier@npm:7.24.7
  ➤ YN0000: │ @babel/helper-validator-option@npm:^7.22.15 can be deduped from @babel/helper-validator-option@npm:7.23.5 to @babel/helper-validator-option@npm:7.24.8
  ➤ YN0000: │ @babel/helper-validator-option@npm:^7.23.5 can be deduped from @babel/helper-validator-option@npm:7.23.5 to @babel/helper-validator-option@npm:7.24.8
  ➤ YN0000: │ caniuse-lite@npm:^1.0.30001580 can be deduped from caniuse-lite@npm:1.0.30001581 to caniuse-lite@npm:1.0.30001642
  ➤ YN0000: │ electron-to-chromium@npm:^1.4.648 can be deduped from electron-to-chromium@npm:1.4.650 to electron-to-chromium@npm:1.4.829
  ➤ YN0000: │ escalade@npm:^3.1.1 can be deduped from escalade@npm:3.1.1 to escalade@npm:3.1.2
  ➤ YN0000: │ picocolors@npm:^1.0.0 can be deduped from picocolors@npm:1.0.0 to picocolors@npm:1.0.1
  ➤ YN0000: │ @babel/helper-environment-visitor@npm:^7.22.20 can be deduped from @babel/helper-environment-visitor@npm:7.22.20 to @babel/helper-environment-visitor@npm:7.24.7
  ➤ YN0000: │ @babel/helper-hoist-variables@npm:^7.22.5 can be deduped from @babel/helper-hoist-variables@npm:7.22.5 to @babel/helper-hoist-variables@npm:7.24.7
  ➤ YN0000: │ @babel/helper-split-export-declaration@npm:^7.22.6 can be deduped from @babel/helper-split-export-declaration@npm:7.24.5 to @babel/helper-split-export-declaration@npm:7.24.7
  ➤ YN0000: │ @babel/helper-split-export-declaration@npm:^7.24.5 can be deduped from @babel/helper-split-export-declaration@npm:7.24.5 to @babel/helper-split-export-declaration@npm:7.24.7
  ➤ YN0000: │ @babel/parser@npm:^7.1.0 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/parser@npm:^7.14.7 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/parser@npm:^7.20.7 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/parser@npm:^7.23.0 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/parser@npm:^7.24.0 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/parser@npm:^7.24.5 can be deduped from @babel/parser@npm:7.24.5 to @babel/parser@npm:7.24.8
  ➤ YN0000: │ @babel/code-frame@npm:^7.0.0 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/code-frame@npm:^7.10.4 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/code-frame@npm:^7.12.13 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/code-frame@npm:^7.22.13 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/code-frame@npm:^7.23.5 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/code-frame@npm:^7.24.2 can be deduped from @babel/code-frame@npm:7.24.2 to @babel/code-frame@npm:7.24.7
  ➤ YN0000: │ @babel/helper-function-name@npm:^7.22.5 can be deduped from @babel/helper-function-name@npm:7.23.0 to @babel/helper-function-name@npm:7.24.7
  ➤ YN0000: │ @babel/helper-function-name@npm:^7.23.0 can be deduped from @babel/helper-function-name@npm:7.23.0 to @babel/helper-function-name@npm:7.24.7
  ➤ YN0000: │ @babel/helper-module-imports@npm:^7.16.7 can be deduped from @babel/helper-module-imports@npm:7.24.3 to @babel/helper-module-imports@npm:7.24.7
  ➤ YN0000: │ @babel/helper-module-imports@npm:^7.22.15 can be deduped from @babel/helper-module-imports@npm:7.24.3 to @babel/helper-module-imports@npm:7.24.7
  ➤ YN0000: │ @babel/helper-module-imports@npm:^7.24.3 can be deduped from @babel/helper-module-imports@npm:7.24.3 to @babel/helper-module-imports@npm:7.24.7
  ➤ YN0000: │ @babel/helper-simple-access@npm:^7.22.5 can be deduped from @babel/helper-simple-access@npm:7.24.5 to @babel/helper-simple-access@npm:7.24.7
  ➤ YN0000: │ @babel/helper-simple-access@npm:^7.24.5 can be deduped from @babel/helper-simple-access@npm:7.24.5 to @babel/helper-simple-access@npm:7.24.7
  ➤ YN0000: │ @babel/helpers@npm:^7.24.5 can be deduped from @babel/helpers@npm:7.24.5 to @babel/helpers@npm:7.24.8
  ➤ YN0000: │ update-browserslist-db@npm:^1.0.13 can be deduped from update-browserslist-db@npm:1.0.13 to update-browserslist-db@npm:1.1.0
  ➤ YN0000: │ @babel/template@npm:^7.20.7 can be deduped from @babel/template@npm:7.24.0 to @babel/template@npm:7.24.7
  ➤ YN0000: │ @babel/template@npm:^7.22.15 can be deduped from @babel/template@npm:7.24.0 to @babel/template@npm:7.24.7
  ➤ YN0000: │ @babel/template@npm:^7.24.0 can be deduped from @babel/template@npm:7.24.0 to @babel/template@npm:7.24.7
  ➤ YN0000: │ @babel/template@npm:^7.3.3 can be deduped from @babel/template@npm:7.24.0 to @babel/template@npm:7.24.7
  ➤ YN0000: │ @babel/template@npm:^7.4.4 can be deduped from @babel/template@npm:7.24.0 to @babel/template@npm:7.24.7
  ➤ YN0000: │ @babel/types@npm:^7.0.0 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.18.9 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.20.7 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.21.5 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.22.15 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.22.19 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.22.5 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.23.0 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.24.0 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.24.5 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.3.3 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.4.4 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/types@npm:^7.8.3 can be deduped from @babel/types@npm:7.24.5 to @babel/types@npm:7.24.9
  ➤ YN0000: │ @babel/generator@npm:^7.23.0 can be deduped from @babel/generator@npm:7.24.5 to @babel/generator@npm:7.24.10
  ➤ YN0000: │ @babel/generator@npm:^7.24.5 can be deduped from @babel/generator@npm:7.24.5 to @babel/generator@npm:7.24.10
  ➤ YN0000: │ @babel/generator@npm:^7.7.2 can be deduped from @babel/generator@npm:7.24.5 to @babel/generator@npm:7.24.10
  ➤ YN0000: │ @babel/highlight@npm:^7.24.2 can be deduped from @babel/highlight@npm:7.24.5 to @babel/highlight@npm:7.24.7
  ➤ YN0000: │ browserslist@npm:^4.22.2 can be deduped from browserslist@npm:4.22.3 to browserslist@npm:4.23.2
  ➤ YN0000: │ @babel/helper-compilation-targets@npm:^7.22.15 can be deduped from @babel/helper-compilation-targets@npm:7.23.6 to @babel/helper-compilation-targets@npm:7.24.8
  ➤ YN0000: │ @babel/helper-compilation-targets@npm:^7.22.6 can be deduped from @babel/helper-compilation-targets@npm:7.23.6 to @babel/helper-compilation-targets@npm:7.24.8
  ➤ YN0000: │ @babel/helper-compilation-targets@npm:^7.23.6 can be deduped from @babel/helper-compilation-targets@npm:7.23.6 to @babel/helper-compilation-targets@npm:7.24.8
  ➤ YN0000: │ @babel/helper-module-transforms@npm:^7.23.3 can be deduped from @babel/helper-module-transforms@npm:7.24.5 to @babel/helper-module-transforms@npm:7.24.9
  ➤ YN0000: │ @babel/helper-module-transforms@npm:^7.24.5 can be deduped from @babel/helper-module-transforms@npm:7.24.5 to @babel/helper-module-transforms@npm:7.24.9
  ➤ YN0000: │ @babel/traverse@npm:^7.18.9 can be deduped from @babel/traverse@npm:7.24.5 to @babel/traverse@npm:7.24.8
  ➤ YN0000: │ @babel/traverse@npm:^7.23.2 can be deduped from @babel/traverse@npm:7.24.5 to @babel/traverse@npm:7.24.8
  ➤ YN0000: │ @babel/traverse@npm:^7.24.5 can be deduped from @babel/traverse@npm:7.24.5 to @babel/traverse@npm:7.24.8
  ➤ YN0000: │ @babel/core@npm:^7.11.6 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ @babel/core@npm:^7.12.3 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ @babel/core@npm:^7.18.9 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ @babel/core@npm:^7.20.12 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ @babel/core@npm:^7.23.0 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ @babel/core@npm:^7.23.2 can be deduped from @babel/core@npm:7.24.5 to @babel/core@npm:7.24.9
  ➤ YN0000: │ 74 packages can be deduped using the highest strategy
  ```
  </details>

### Deprecated

- None

### Removed

- None

### Fixed

- None

## How to test

1. Checkout this branch: `git checkout origin/build/dependencies/dedupe`
2. Run `yarn` and ensure all dependencies are correctly installed without duplication and that there are no issues related to missing or incompatible dependencies.
3. Run `yarn test` and verify that all tests run and pass.
4. Run `yarn dev` and verify that the application runs as expected.
5. Run `yarn build` and verify that the application builds as expected.
6. Run `yarn build-storybook` and verify the Storybook build succeeds.
