### PR TITLE
ci(github): upgrade actions to v4

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -21,10 +21,10 @@ jobs:
       CI: true
     steps:
       - name: CHECKOUT
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: INSTALL - node.js, yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -42,7 +42,7 @@ jobs:
 
       - name: CACHE - yarn dependencies
         id: yarn-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}


### PR DESCRIPTION
## Summary

Updated the GitHub Actions used in the CI/CD workflow to their latest versions to ensure compatibility and leverage the latest features and improvements.

### Added

- None

### Changed

- Updated `actions/checkout` from `v3` to `v4`.
- Updated `actions/setup-node` from `v3` to `v4`.
- Updated `actions/cache` from `v3` to `v4`.

### Deprecated

- None

### Removed

- None

### Fixed

- None

## How to test

1. Checkout this branch: `git checkout origin/<INSERT_BRANCH_NAME_HERE>`
2. Verify the `.github/workflows/cicd.yaml` file for syntax errors.
3. Push a commit to trigger the CI/CD workflow and ensure it completes successfully.
4. Check that all steps in the workflow execute as expected without any errors related to the updated actions.
5. Verify that the application builds and runs as expected after the workflow completes.
