### PR TITLE
chore: change package.json license from UNLICENSED to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "template-vite-react",
   "private": true,
   "version": "0.0.0-semantic-release",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "description": "Boilerplate for React + Vite project",
   "homepage": "https://github.com/aquia-inc/template-vite-react#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

Changes the project license in the `package.json` file from `UNLICENSED` to `MIT` to reflect the intended licensing in [LICENSE.md](https://github.com/aquia-inc/template-vite-react/blob/main/LICENSE.md).

### Added

- None

### Changed

- Updated the license in `package.json` from `UNLICENSED` to `MIT`.

### Deprecated

- None

### Removed

- None

### Fixed

- None

## How to test

- Verify that the `package.json` file reflects the change in license from `UNLICENSED` to `MIT` and matches the license in [LICENSE.md](https://github.com/aquia-inc/template-vite-react/blob/main/LICENSE.md)