### PR TITLE
fix: resolve code quality findings

### DIFF
--- a/src/views/SignIn/useSignIn.test.tsx
+++ b/src/views/SignIn/useSignIn.test.tsx
@@ -14,12 +14,12 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@/hooks/useAlert')
 jest.mock('@/store/auth/useAuthDispatch')
 jest.mock('@/store/auth/useAuthState')
-;(useAuthDispatch as jest.Mock).mockReturnValue(jest.fn())
-;(useNavigate as jest.Mock).mockReturnValue(jest.fn())
 const setAlertMock = jest.fn()
 
 beforeEach(() => {
   jest.clearAllMocks()
+  ;(useAuthDispatch as jest.Mock).mockReturnValue(jest.fn())
+  ;(useNavigate as jest.Mock).mockReturnValue(jest.fn())
   ;(useAlert as jest.Mock).mockReturnValue({ setAlert: setAlertMock })
 })
 
@@ -27,7 +27,11 @@ test('handles form submission', async () => {
   ;(loginUser as jest.Mock).mockResolvedValueOnce({})
   const { result } = renderHook(useSignIn)
   await act(async () => {
-    result.current.handleSubmit()
+    result.current.setValue('email', 'test@test.com')
+    result.current.setValue('password', 'password')
+  })
+  await act(async () => {
+    await result.current.handleSubmit()
   })
   await waitFor(() => {
     expect(result.current.loading).toBe(false)
@@ -65,7 +69,11 @@ test('handles form submission error', async () => {
   )
   const { result } = renderHook(useSignIn)
   await act(async () => {
-    result.current.handleSubmit()
+    result.current.setValue('email', 'test@test.com')
+    result.current.setValue('password', 'password')
+  })
+  await act(async () => {
+    await result.current.handleSubmit()
   })
   await waitFor(() => {
     expect(result.current.loading).toBe(false)

--- a/src/views/SignIn/useSignIn.test.tsx
+++ b/src/views/SignIn/useSignIn.test.tsx
@@ -29,7 +29,7 @@ test('handles form submission', async () => {
   await act(async () => {
     result.current.handleSubmit()
   })
-  waitFor(() => {
+  await waitFor(() => {
     expect(result.current.loading).toBe(false)
     expect(loginUser).toHaveBeenCalledWith(expect.any(Function), {
       email: 'test@test.com',
@@ -44,7 +44,7 @@ test('handles federated sign in', async () => {
   await act(async () => {
     await result.current.handleFederatedSignIn()
   })
-  waitFor(() => {
+  await waitFor(() => {
     expect(Auth.federatedSignIn).toHaveBeenCalledWith({ provider: 'COGNITO' })
   })
 })
@@ -54,7 +54,7 @@ test('toggles password visibility', async () => {
   await act(() => {
     result.current.setShowPassword(true)
   })
-  waitFor(() => {
+  await waitFor(() => {
     expect(result.current.showPassword).toBe(true)
   })
 })
@@ -67,7 +67,7 @@ test('handles form submission error', async () => {
   await act(async () => {
     result.current.handleSubmit()
   })
-  waitFor(() => {
+  await waitFor(() => {
     expect(result.current.loading).toBe(false)
     expect(setAlertMock).toHaveBeenCalledWith({
       message: 'There was an error logging in. Please try again.',
@@ -84,7 +84,7 @@ test('handles federated sign in error', async () => {
   await act(async () => {
     await result.current.handleFederatedSignIn()
   })
-  waitFor(() => {
+  await waitFor(() => {
     expect(setAlertMock).toHaveBeenCalledWith({
       message: 'There was an error with the identity provider.',
       severity: 'error',


### PR DESCRIPTION
_This PR applies 1/5 suggestions from code quality [AI findings](https://github.com/aquia-inc/template-vite-react/security/quality/ai-findings). 4 suggestions were skipped to avoid creating conflicts._

This pull request makes minor improvements to the test suite for the `useSignIn` hook by ensuring asynchronous assertions are properly awaited. The changes enhance test reliability and correctness.

* Testing improvements:
  * Replaced `waitFor` with `await waitFor` in all relevant tests in `src/views/SignIn/useSignIn.test.tsx` to ensure asynchronous assertions are awaited, preventing potential timing issues and improving test accuracy. [[1]](diffhunk://#diff-bc2a0e24e4f3ec4ad55ce653f4f3b90698e408c378410d500a9af0e32d687c88L32-R32) [[2]](diffhunk://#diff-bc2a0e24e4f3ec4ad55ce653f4f3b90698e408c378410d500a9af0e32d687c88L47-R47) [[3]](diffhunk://#diff-bc2a0e24e4f3ec4ad55ce653f4f3b90698e408c378410d500a9af0e32d687c88L57-R57) [[4]](diffhunk://#diff-bc2a0e24e4f3ec4ad55ce653f4f3b90698e408c378410d500a9af0e32d687c88L70-R70) [[5]](diffhunk://#diff-bc2a0e24e4f3ec4ad55ce653f4f3b90698e408c378410d500a9af0e32d687c88L87-R87)