### PR TITLE
chore: replace vite swc react plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/react-helmet": "^6.1.11",
     "@types/testing-library__jest-dom": "^6.0.0",
     "@types/uuid": "^9.0.8",
-    "@vitejs/plugin-react-swc": "^4.3.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "camelcase": "^6.3.0",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "dotenv": "^16.6.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath, URL } from 'node:url'
 import { defineConfig, loadEnv, type PluginOption } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { normalizePublicBasePath } from './src/utils/publicBasePath'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7967,7 +7967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.15.11, @swc/core@npm:^1.15.18":
+"@swc/core@npm:^1.15.18":
   version: 1.15.18
   resolution: "@swc/core@npm:1.15.18"
   dependencies:
@@ -8861,18 +8861,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react-swc@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@vitejs/plugin-react-swc@npm:4.3.0"
-  dependencies:
-    "@rolldown/pluginutils": "npm:1.0.0-rc.7"
-    "@swc/core": "npm:^1.15.11"
-  peerDependencies:
-    vite: ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 10/a4b010ec9f93fe8e3dd2172a8712812592c7ad271dcf9f5887685ac74673448ecd82772ba3f8595a0a09d358789b3425a509cf80c92454ba09d164c9472c5248
-  languageName: node
-  linkType: hard
-
 "@vitejs/plugin-react@npm:^3.0.1":
   version: 3.1.0
   resolution: "@vitejs/plugin-react@npm:3.1.0"
@@ -8885,6 +8873,24 @@ __metadata:
   peerDependencies:
     vite: ^4.1.0-beta.0
   checksum: 10/54baf15170faed08c5c050ed6ac3b071e743d703f2c26ae685bf362bbaa2d8a733a98af0639f0662d474d95a6d91d008da9de8f3a51cc3e6660c4e642399cf2c
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-react@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@vitejs/plugin-react@npm:6.0.1"
+  dependencies:
+    "@rolldown/pluginutils": "npm:1.0.0-rc.7"
+  peerDependencies:
+    "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+    babel-plugin-react-compiler: ^1.0.0
+    vite: ^8.0.0
+  peerDependenciesMeta:
+    "@rolldown/plugin-babel":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+  checksum: 10/a525799252fa6c12bf9a0a367b17dfc3d5e8e02ec0b5b81554db9d97b764c554be6b0686e3dd385b0ac0350f0c023120ce712d79feedd99fa2cb854b7cd1e960
   languageName: node
   linkType: hard
 
@@ -20224,7 +20230,7 @@ __metadata:
     "@types/react-helmet": "npm:^6.1.11"
     "@types/testing-library__jest-dom": "npm:^6.0.0"
     "@types/uuid": "npm:^9.0.8"
-    "@vitejs/plugin-react-swc": "npm:^4.3.0"
+    "@vitejs/plugin-react": "npm:^6.0.1"
     aws-amplify: "npm:^5.3.29"
     camelcase: "npm:^6.3.0"
     classnames: "npm:^2.5.1"


### PR DESCRIPTION
## Summary

Replaces `@vitejs/plugin-react-swc` with `@vitejs/plugin-react` and updates the Vite React plugin import in `vite.config.ts`.

### Added

N/A

### Changed

- Swapped the Vite React plugin package from `@vitejs/plugin-react-swc` to `@vitejs/plugin-react`.
- Updated `vite.config.ts` to import React support from `@vitejs/plugin-react`.
- Refreshed `yarn.lock` for the focused plugin replacement.

### Deprecated

N/A

### Removed

- Removed the direct `@vitejs/plugin-react-swc` dev dependency.

### Fixed

- Fixes the deprecated Vite React SWC warning caused by the SWC plugin using deprecated `esbuild` options.

## How to test

Validation run locally:

- `yarn lint:js` passed.
- `yarn lint:other` passed.
- `yarn build` passed, with no deprecated Vite React SWC `esbuild` warning.
- `yarn build-storybook` passed, with no deprecated Vite React SWC `esbuild` warning.
- `yarn test:e2e` passed after installing the Playwright Chromium binary for this branch.

Remaining non-blocking warnings observed:

- Browserslist `caniuse-lite` is outdated.
- Production and Storybook builds still report large chunk warnings.
- Storybook 7 emits existing warnings for missing `@mui/icons-material` package metadata, unresolved `sb-common-assets/fonts.css` at build time, and direct `eval` usage in `telejson`.
- E2E output still reports the existing `NO_COLOR`/`FORCE_COLOR` warning.