### PR TITLE
chore(deps): upgrade fontawesome free

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/fontawesome-free": "^7.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "^9.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,10 +1916,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-free@npm:^6.7.2":
-  version: 6.7.2
-  resolution: "@fortawesome/fontawesome-free@npm:6.7.2"
-  checksum: 10/88101fee12470ede1e7f2588b86121924259d98889b950e2ccde71d934f4f344b592d1360700de4e92d81262014d3ae33fe995c7799f2be2abddcee3102413d6
+"@fortawesome/fontawesome-free@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@fortawesome/fontawesome-free@npm:7.2.0"
+  checksum: 10/a5c1aedc57017d57f7d836ab453b797c8423a11db4f06eae892f84544fa2a9c1efe322e47d49f83113552d4ddb104cab831bfaa8dc41ea782f8346553fa4c83f
   languageName: node
   linkType: hard
 
@@ -13910,7 +13910,7 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
     "@eslint/js": "npm:^10.0.1"
-    "@fortawesome/fontawesome-free": "npm:^6.7.2"
+    "@fortawesome/fontawesome-free": "npm:^7.2.0"
     "@hookform/resolvers": "npm:^5.2.2"
     "@mui/icons-material": "npm:^9.0.1"
     "@mui/lab": "npm:^9.0.0-beta.3"


### PR DESCRIPTION
## Summary

Upgrade Font Awesome Free to v7.

### Added

- None.

### Changed

- Updated `@fortawesome/fontawesome-free` from `^6.7.2` to `^7.2.0`.
- Refreshed `yarn.lock` for the Font Awesome v7 package.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

## How to test

Validated locally with Node 24 via `mise`:

- `yarn install --immutable`
- `yarn lint`
- `yarn test`
- `yarn build`
- `yarn build-storybook`

Notes:

- No Font Awesome imports, CSS includes, `fa-*` classes, or SCSS references were found outside `package.json`.
- Font Awesome v7 breaking areas around fixed-width defaults, accessibility helpers, SCSS syntax, webfont formats, and removed Less support are not currently applicable to this repo.
- Existing peer dependency warnings remain during install.
- Existing React Router hydration and color-env warnings remain during tests.
- Existing Vite/Storybook chunk-size warnings remain during builds.
