### PR TITLE
docs: update license year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 Aquia Inc.
+Copyright (c) 2023-2026 Aquia Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

### Changed

- Updated the MIT license copyright year from `2023` to `2023-2026`.

## How to test

- `git diff --check`
- `rg -n "Copyright \(c\) 2023-2026 Aquia Inc\." LICENSE.md`