### PR TITLE
fix(auth): prevent dashboard navigation after failed sign-in

### DIFF
--- a/src/views/SignIn/useSignIn.test.tsx
+++ b/src/views/SignIn/useSignIn.test.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import loginUser from '@/actions/loginUser'
 import useAlert from '@/hooks/useAlert'
+import { Routes } from '@/router/constants'
 import useAuthDispatch from '@/store/auth/useAuthDispatch'
 import useSignIn from '@/views/SignIn/useSignIn'
 import AuthError from '@/errors/AuthError'
@@ -62,7 +63,7 @@ test('handles form submission', async () => {
       email: 'test@test.com',
       password: 'password',
     })
-    expect(navigateMock).toHaveBeenCalledWith('/app')
+    expect(navigateMock).toHaveBeenCalledWith(Routes.DASHBOARD)
   })
 })
 

--- a/src/views/SignIn/useSignIn.test.tsx
+++ b/src/views/SignIn/useSignIn.test.tsx
@@ -43,7 +43,11 @@ beforeEach(() => {
 })
 
 test('handles form submission', async () => {
-  ;(loginUser as jest.Mock).mockResolvedValueOnce({})
+  ;(loginUser as jest.Mock).mockResolvedValueOnce({
+    jwtToken: 'jwtToken',
+    email: 'test@test.com',
+    username: 'username',
+  })
   const { result } = renderHook(useSignIn)
   await act(async () => {
     result.current.setValue('email', 'test@test.com')
@@ -58,7 +62,7 @@ test('handles form submission', async () => {
       email: 'test@test.com',
       password: 'password',
     })
-    expect(navigateMock).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith('/app')
   })
 })
 
@@ -96,6 +100,27 @@ test('handles form submission error', async () => {
   })
   await waitFor(() => {
     expect(result.current.loading).toBe(false)
+    expect(navigateMock).not.toHaveBeenCalled()
+    expect(setAlertMock).toHaveBeenCalledWith({
+      message: 'There was an error logging in. Please try again.',
+      severity: 'error',
+    })
+  })
+})
+
+test('does not navigate when login dispatches failure and returns no user data', async () => {
+  ;(loginUser as jest.Mock).mockResolvedValueOnce(undefined)
+  const { result } = renderHook(useSignIn)
+  await act(async () => {
+    result.current.setValue('email', 'test@test.com')
+    result.current.setValue('password', 'password')
+  })
+  await act(async () => {
+    await result.current.handleSubmit()
+  })
+  await waitFor(() => {
+    expect(result.current.loading).toBe(false)
+    expect(navigateMock).not.toHaveBeenCalled()
     expect(setAlertMock).toHaveBeenCalledWith({
       message: 'There was an error logging in. Please try again.',
       severity: 'error',

--- a/src/views/SignIn/useSignIn.ts
+++ b/src/views/SignIn/useSignIn.ts
@@ -103,15 +103,20 @@ const useSignIn = (): useSignInReturnType => {
       const { email, password } = data
       setLoading(true)
       try {
-        await loginUser(dispatch, { email, password })
-        setLoading(false)
+        const userData = await loginUser(dispatch, { email, password })
+
+        if (!userData) {
+          throw new Error('Login failed')
+        }
+
         navigate(Routes.DASHBOARD)
       } catch {
-        setLoading(false)
         setAlert({
           message: 'There was an error logging in. Please try again.',
           severity: 'error',
         })
+      } finally {
+        setLoading(false)
       }
     },
     [authEnabled, dispatch, navigate, setAlert],


### PR DESCRIPTION
## Summary

Fixes #410.

### Added

- Focused test coverage for the case where password sign-in dispatches failure and returns no user data.

### Changed

- Password sign-in now navigates to the dashboard only when `loginUser` returns authenticated user data.
- Loading state is cleared from a `finally` block on both successful and failed sign-in attempts.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Failed username/password sign-in no longer navigates to `/app`.
- Existing login failure alert path is shown for rejected logins and resolved-without-user-data failures.

## How to test

- `mise exec node@24 -- yarn jest src/views/SignIn/useSignIn.test.tsx --runInBand --coverage=false`
- `mise exec node@24 -- yarn jest src/actions/loginUser.test.tsx --runInBand --coverage=false`
- `mise exec node@24 -- yarn test`
- `mise exec node@24 -- yarn lint`
- `mise exec node@24 -- yarn build`
