### PR TITLE
ci: add storybook and release validation gates

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: RELEASE - dry-run validation
         if: github.event_name == 'pull_request'
         run: yarn semantic-release --dry-run --no-ci --branches main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: INSTALL - Playwright browser
         run: yarn test:e2e:install

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -54,6 +54,16 @@ jobs:
       - name: INSTALL - dependencies
         run: yarn install --immutable
 
+      - name: COMMITLINT - PR title
+        if: github.event_name == 'pull_request'
+        run: printf '%s\n' "$PR_TITLE" | yarn commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+
+      - name: RELEASE - dry-run validation
+        if: github.event_name == 'pull_request'
+        run: yarn semantic-release --dry-run --no-ci --branches main
+
       - name: INSTALL - Playwright browser
         run: yarn test:e2e:install
 
@@ -65,6 +75,13 @@ jobs:
 
       - name: BUILD
         run: yarn build
+        env:
+          VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
+          VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}
+          VITE_IDP_ENABLED: 'false'
+
+      - name: BUILD - Storybook
+        run: yarn build-storybook
         env:
           VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
           VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}


### PR DESCRIPTION
## Summary

### Added

- Added PR CI enforcement for the pull request title through the existing commitlint config.
- Added a PR-safe semantic-release dry-run command that validates the release config loads while preserving the main-branch publish guard.
- Added Storybook production build validation to the existing CI build job.

### Changed

- CI now runs `yarn build-storybook` alongside the app build for pull requests and main pushes.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

## How to test

- `mise exec node@24 -- yarn install --immutable`
- `printf "%s\n" "ci: add storybook and release validation gates" | mise exec node@24 -- yarn commitlint`
- `mise exec node@24 -- yarn semantic-release --dry-run --no-ci --branches main`
- `mise exec node@24 -- yarn build-storybook`
- `mise exec node@24 -- yarn lint`
- `mise exec node@24 -- yarn test`
- `mise exec node@24 -- yarn build`

Deferred follow-up: Pages/base-path smoke and broader Playwright expansion remain deferred until Agent A auth correctness and Agent C demo dashboard shape are known.