### PR TITLE
docs: improve template contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,177 +1,104 @@
-# CONTRIBUTING.md
+# Contributing To template-vite-react
 
-## Contributing to [Project Name]
+This repository is a Vite React application template. Keep contributions focused,
+validated, and easy to reuse in downstream projects.
 
-Thank you for your interest in contributing to [Project Name]! We're excited to have you as part of our growing community. This document outlines the guidelines and best practices for contributing to this project.
+## Local Setup
 
-## Table of Contents
+Use the pinned runtime and package manager:
 
-1. [CONTRIBUTING.md](#contributingmd)
-1. [Contributing to \[Project Name\]](#contributing-to-project-name)
-1. [Table of Contents](#table-of-contents)
-1. [Code of Conduct](#code-of-conduct)
-1. [Issues](#issues)
-1. [Bug Reports](#bug-reports)
-1. [Feature Requests](#feature-requests)
-1. [Pull Requests](#pull-requests)
-1. [Coding Standards](#coding-standards)
-1. [Testing](#testing)
-1. [Documentation](#documentation)
-1. [Community](#community)
+```shell
+nvm use
+corepack enable
+yarn install --immutable
+sh ./scripts/post-install.sh
+```
 
-## Code of Conduct
+The post-install script creates `.env.development.local` from `.env.example`.
+Dummy Cognito values are safe for booting the app, but use real values only when
+testing auth against an owned user pool.
 
-All contributors to this project are expected to follow our [Code of Conduct][code-of-conduct]. By participating in this project, you agree to abide by its terms.
+## Branches And Commits
 
-## Issues
+- Create short-lived branches from the latest `main`.
+- Keep each pull request scoped to one concern.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit
+  messages and PR titles, for example `fix(auth): handle missing Cognito config`.
+- Rebase or update from `main` before asking for review when the branch is stale.
+- Sign commits when required by the repository or organization policy.
 
-Before submitting an issue, please:
+## Validation
 
-1.  Check if the issue has already been reported by searching the existing issues.
-2.  Follow the issue template provided and fill in all the required information.
+Run the checks that match your change. For most code changes, run:
 
-When creating an issue, please include:
+```shell
+yarn lint
+yarn test
+yarn build
+```
 
-1.  A clear and concise title.
-2.  A detailed description of the problem (bug) or feature request.
-3.  Steps to reproduce the issue (for bug reports) or use cases for new features.
-4.  Expected behavior and actual behavior (for bug reports).
-5.  Screenshots, logs, or error messages, if applicable.
-6.  Your operating system, browser, or platform version, if relevant.
-7.  The version or commit of [Project Name] you are using.
+For UI, routing, or browser behavior changes, also run:
 
-Please note that issues that do not follow the guidelines may be deprioritized, or closed with minimal interaction.
+```shell
+yarn test:e2e:install
+yarn test:e2e
+```
 
-### Bug Reports
+For shared UI or Storybook changes, also run:
 
-If you're reporting a bug, please follow these guidelines to help us reproduce and fix the issue:
+```shell
+yarn build-storybook
+```
 
-1.  Describe the issue and the steps to reproduce it.
-2.  Explain the expected behavior and the actual behavior you encountered.
-3.  Provide a minimal, self-contained example or code snippet that reproduces the issue.
-4.  If applicable, include any relevant logs, error messages, or screenshots.
+CI installs dependencies with `yarn install --immutable`, installs Playwright
+Chromium, runs `yarn ci`, runs `yarn test:e2e`, builds the app, and runs
+semantic-release on pushes to `main`.
 
-### Feature Requests
+## Environment And Auth Changes
 
-For feature requests, please provide the following information:
+Document any new `VITE_*` variable in `.env.example` and `README.md`. Keep the
+GitHub Pages demo safe by leaving real Cognito values out of committed files and
+workflow defaults.
 
-1.  A clear and concise description of the feature.
-2.  An explanation of why this feature would be useful for the project and the community.
-3.  If possible, provide examples of how the feature could be used, including code snippets or mockups.
-4.  If applicable, list any potential drawbacks or limitations of implementing the feature.
+Auth uses AWS Amplify/Cognito and should continue to degrade cleanly when
+Cognito settings are blank or invalid. Include local validation notes in the PR
+when auth behavior changes.
 
-Remember that the more detailed and specific your feature request is, the easier it will be for us to evaluate and potentially implement it.
+## Dependency Changes
+
+Keep dependency updates in dedicated PRs. A dependency PR should explain:
+
+- direct dependencies changed
+- notable transitive audit or deprecation impact
+- lockfile-only changes, if any
+- validation commands and results
+- rollback notes when the update affects build, test, release, auth, or UI
+  tooling
+
+Do not use broad Yarn resolutions or package overrides without an isolated
+validation plan and a clear reason.
+
+## Documentation Changes
+
+Update docs in the same PR as the behavior they describe. For docs-only changes,
+run at least:
+
+```shell
+yarn lint
+```
 
 ## Pull Requests
 
-We follow a trunk-based development model for our codebase. This means that all changes should be made in short-lived feature branches and merged directly into the `main` branch through pull requests. Please follow these guidelines to ensure a smooth and efficient contribution process:
+Before opening a PR:
 
-1.  Create a new branch from the latest `main` branch for each new feature or bug fix. Use a descriptive branch name that reflects the changes being made.
-2.  Keep your changes focused and limited to a single feature or bug fix. If you find another issue while working on your branch, create a new issue and a separate branch for it.
-3.  Commit your changes using the [Conventional Commits](https://www.conventionalcommits.org/) standard. This helps maintain a clean and readable commit history. Your commit messages should follow this format: `<type>(<scope>): <description>`. For example:
-    ```
-    fix(auth): resolve login failure due to incorrect token validation
-    ```
-4.  Sign your commits using GPG. This adds an extra layer of security and ensures the authenticity of your contributions. Follow the [GitHub documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) to set up and use GPG.
-5.  Before submitting a pull request, ensure that your changes are up-to-date with the latest `main` branch. Rebase your branch if necessary.
-6.  Open a pull request, and provide a clear and concise title and description that follows the Conventional Commits standard. Include any relevant issue numbers in the description by using keywords like "Closes #123" or "Fixes #123".
-7.  Request a review from one or more project maintainers or collaborators. Be prepared to address any feedback, suggestions, or requested changes in a timely manner.
-8.  Once your pull request is approved and all tests have passed, a project maintainer will merge your changes into the `main` branch.
+- confirm `git status -sb` contains only intended changes
+- fill out `.github/PULL_REQUEST_TEMPLATE.md`
+- include exact validation commands and results
+- link related issues with closing keywords only when the PR actually resolves
+  them
 
-Please note that pull requests that do not follow the guidelines or are incomplete may be closed without explanation. We appreciate your understanding and cooperation in maintaining a high-quality codebase.
-
-## Coding Standards
-
-Adhering to a consistent set of coding standards is crucial for maintaining a clean, readable, and maintainable codebase. By following these guidelines, you help ensure that [Project Name] remains a high-quality project that is easy to understand, modify, and extend.
-
-Here are some general guidelines for writing code that conforms to the project's coding standards:
-
-1.  Write clean and readable code: Keep your code simple, clear, and concise. Use descriptive variable and function names, add comments to explain complex or non-obvious parts of the code, and break down large functions or classes into smaller, more manageable pieces.
-
-1.  Optimize for performance and security: Write code that is efficient, secure, and avoids common pitfalls and vulnerabilities. Be mindful of performance bottlenecks, memory leaks, and security risks when designing and implementing your solutions.
-
-1.  Document your code: Include comments and docstrings to explain the purpose, functionality, and usage of your code. This helps other contributors understand your code and makes it easier for them to maintain and extend it. If you find that you need a lot of context within your comment, create a separate page with the needed documentation.
-
-1.  Stay consistent with existing code: When making changes or additions to the codebase, try to match the style, structure, and conventions of the existing code. This ensures that the codebase remains coherent and easy to navigate.
-
-1.  Adhere to the DRY (Don't Repeat Yourself) principle: Avoid duplicating code and logic across the codebase. Instead, refactor and reuse code whenever possible to minimize maintenance overhead and potential inconsistencies.
-
-To contribute code that follows the project's coding standards:
-
-1.  Create a new branch from the latest `main` branch.
-2.  Make your changes or additions to the code, following the guidelines above.
-3.  Commit your changes using the [Conventional Commits](https://www.conventionalcommits.org/) standard, as described in the [Pull Requests](#pull-requests section.
-4.  Sign your commits using GPG, as described in the [Pull Requests](#pull-requests) section.
-5.  Open a pull request with a clear and concise title and description, following the Conventional Commits standard.
-6.  Request a review from one or more project maintainers or collaborators.
-
-By adhering to the project's coding standards, you help create a strong foundation for the continued growth and success of [Project Name]. Thank you for your commitment to maintaining a high-quality codebase!
-
-## Testing
-
-Thorough and consistent testing is essential for maintaining the stability, reliability, and security of [Project Name]. By contributing tests, you help ensure that the project remains robust and resistant to bugs, regressions, and vulnerabilities. Here are some guidelines for writing and contributing tests:
-
-1.  Follow the testing framework and conventions: Familiarize yourself with the testing framework, tools, and conventions used in the project. Write tests that are consistent with the existing test suite and follow best practices.
-2.  Write tests for new features and bug fixes: When adding a new feature or fixing a bug, make sure to include tests that cover the changes. This helps prevent regressions and ensures that the changes work as intended across different environments and configurations.
-3.  Improve existing tests: If you find existing tests that are incomplete, unclear, or lacking in coverage, feel free to improve them. This may involve refactoring, adding new test cases, or improving test descriptions.
-4.  Ensure tests are reliable and maintainable: Write tests that are easy to understand, maintain, and update. Avoid using hard-coded values, magic numbers, or brittle logic that may cause tests to fail unexpectedly or become difficult to maintain.
-5.  Run tests locally: Before submitting a pull request, run the entire test suite locally to ensure that your changes do not introduce new test failures or break existing functionality.
-
-To contribute tests, follow the same process as for code contributions:
-
-1.  Create a new branch from the latest `main` branch.
-2.  Add or modify tests as needed.
-3.  Commit your changes using the [Conventional Commits](https://www.conventionalcommits.org/) standard, with a `test` type in the commit message. For example:
-    ```
-    test(auth): add test cases for login failure scenarios
-    ```
-4.  Sign your commits using GPG, as described in the [Pull Requests](#pull-requests) section.
-5.  Open a pull request with a clear and concise title and description, following the Conventional Commits standard.
-6.  Request a review from one or more project maintainers or collaborators.
-
-Your contributions to the project's test suite help ensure the long-term quality and stability of [Project Name]. Thank you for your efforts in keeping the project robust and reliable!
-
-## Documentation
-
-Well-written and up-to-date documentation is crucial for the success and usability of any project. Contributions to improve the documentation are highly appreciated and play a vital role in helping other users and developers understand, use, and extend [Project Name].
-
-Here are some guidelines for contributing to the project's documentation:
-
-1.  Stay consistent: Follow the existing documentation style, structure, and format. This ensures that the documentation remains coherent and easy to navigate.
-2.  Use clear and concise language: Write in simple, easy-to-understand language. Avoid jargon, complex sentences, or unnecessary information. Keep in mind that the documentation should be accessible to users with various levels of expertise.
-3.  Provide examples: Whenever possible, include examples, code snippets, or screenshots to illustrate your points. This helps users better understand the concepts and apply them in practice.
-4.  Keep documentation up-to-date: Make sure to update the documentation whenever you make changes to the code, fix bugs, or introduce new features. Outdated documentation can cause confusion and hinder the adoption of the project.
-5.  Proofread and review: Before submitting your changes, proofread your work to ensure it is free of grammatical errors, typos, or inconsistencies. Request reviews from other contributors or maintainers to ensure the quality and accuracy of the documentation.
-6.  Organize and structure: Ensure that the documentation is well-organized and structured, with a logical flow of information. Use headings, subheadings, and lists to break up large blocks of text and make the content more readable.
-
-To contribute to the documentation, follow the same process as for code contributions:
-
-1.  Create a new branch from the latest `main` branch.
-2.  Make your changes or additions to the documentation.
-3.  Commit your changes using the [Conventional Commits](https://www.conventionalcommits.org/) standard, with a `docs` type in the commit message. For example:
-    ```
-    docs(api): add examples and improve clarity for authentication section
-    ```
-4.  Sign your commits using GPG, as described in the [Pull Requests](#pull-requests) section.
-5.  Open a pull request with a clear and concise title and description, following the Conventional Commits standard.
-6.  Request a review from one or more project maintainers or collaborators.
-
-By contributing to the documentation, you're helping to make [Project Name] more accessible and user-friendly for everyone. Thank you for your valuable contributions!
-
-## Community
-
-We are committed to fostering an open, inclusive, and welcoming community around [Project Name]. By contributing to this project, you are joining a diverse group of developers, users, and enthusiasts who share a common passion for improving and advancing cybersecurity.
-
-Here are some ways to get involved and stay connected with the community:
-
-1.  Join the discussion in our GitHub Issues! Ask questions, share your ideas, or help others with their issues.
-2.  Attend community events: Look for meetups, conferences, webinars, or other events related to [Project Name] and cybersecurity. These gatherings provide opportunities for learning, networking, and collaboration.
-3.  Spread the word: Share your experiences and knowledge about [Project Name] with your network, colleagues, or friends. Write blog posts, create tutorials or present talks about the project and its benefits.
-4.  Provide feedback: Your feedback is invaluable to the continued development and improvement of the project. Share your thoughts on new features, report bugs, or suggest enhancements through GitHub issues or other communication channels.
-5.  Support other contributors: Encourage and support fellow contributors by reviewing their pull requests, answering their questions, or providing mentorship.
-6.  Stay up-to-date: Follow the project's news, announcements, and releases on social media, newsletters, or the project's website. This will help you stay informed about the latest developments and opportunities for collaboration.
-
-Remember that everyone in the community is expected to follow the [Code of Conduct][code-of-conduct] and contribute respectfully and constructively. Let's work together to make [Project Name] a thriving and successful project that benefits everyone involved.
+All contributors are expected to follow the shared
+[Code of Conduct][code-of-conduct].
 
 <!-- LINKS -->
 

--- a/README.md
+++ b/README.md
@@ -2,106 +2,152 @@
 
 ## Overview
 
-This project contains the application's UI built with React, Vite, TypeScript, and SWC. It requires Node.js v24, [nvm](https://github.com/nvm-sh/nvm) (or [n](https://github.com/tj/n)), and Yarn v4.
+This repository is a single-page Vite React application template. It includes
+React 19, TypeScript, React Router, MUI, optional AWS Amplify/Cognito auth,
+Storybook, Jest with SWC transforms, Playwright smoke tests, semantic-release,
+and a GitHub Pages demo workflow.
+
+The template is intended to be copied or forked for application work, so local
+setup, validation, and release behavior are kept explicit.
 
 ## System Requirements
 
 - [Node 24](https://nodejs.org/en/download)
-- [Yarn](https://yarnpkg.com/getting-started/install)
-- [GitLeaks](https://github.com/gitleaks/gitleaks/tree/master#installing)
+- Yarn 4.14.1, pinned by `packageManager`, `.yarnrc.yml`, and
+  `.yarn/releases/yarn-4.14.1.cjs`
+- [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n), or another
+  Node version manager
+- [GitLeaks](https://github.com/gitleaks/gitleaks/tree/master#installing) for
+  local secret scanning
 
 ## Getting Started
 
-1. Clone the repository and `cd` into the root directory:
+1. Clone the repository and change into the root directory:
 
 ```shell
-git clone git@github.com:aquia/template-vite-react.git
-
+git clone git@github.com:aquia-inc/template-vite-react.git
 cd template-vite-react
 ```
 
-2. Setup Node.js and Yarn
+2. Select the pinned Node version and enable Yarn through Corepack:
 
 ```shell
 # using nvm
-nvm install --latest-npm
+nvm install
 nvm use
 
-# using n
-n install auto
-n use auto
-
-# enable corepack
-corepack enable yarn
+# enable package-manager shims
+corepack enable
 ```
 
 3. Install dependencies:
 
 ```shell
-yarn
+yarn install --immutable
 ```
 
-3. Install pre-commit hooks:
+4. Install or refresh local hooks:
 
 ```shell
 yarn prepare
 ```
 
-## Building
-
-To build the application, run the following from the root directory:
-
-```shell
-yarn build
-```
-
-## Testing
-
-To run unit tests, run the following from the root directory:
-
-```shell
-yarn test
-```
-
-To install Playwright browser dependencies, run:
-
-```shell
-yarn test:e2e:install
-```
-
-To run Playwright E2E smoke tests, run:
-
-```shell
-yarn test:e2e
-```
-
-For headed browser debugging:
-
-```shell
-yarn test:e2e:headed
-```
-
-To lint all files, run the following from the root directory:
-
-```shell
-yarn lint
-```
-
-CI runs both `yarn ci` (lint + Jest) and `yarn test:e2e` on pull requests.
-
-## Developing
-
-First, run the post-install script to create the local development environment file from the example environment file.
+5. Create the local development env file:
 
 ```shell
 sh ./scripts/post-install.sh
 ```
 
-To start the local development server, run the following from the root directory:
+The post-install script copies `.env.example` to `.env.development.local`.
+Update the copied file for real Cognito values only when testing auth locally.
+
+## Environment And Auth
+
+The app reads public Vite environment variables from `.env*` files. Local
+development starts from `.env.example`, which includes dummy values that keep the
+app bootable.
+
+Important variables:
+
+- `VITE_PUBLIC_BASE_PATH`: router and asset base path. Use `/` for local dev.
+- `VITE_CF_DOMAIN`: public app origin used by auth redirects.
+- `VITE_IDP_ENABLED`: set to `true` only when the external identity provider
+  button should be shown.
+- `VITE_AWS_REGION`, `VITE_COGNITO_DOMAIN`, `VITE_USER_POOL_ID`,
+  `VITE_USER_POOL_CLIENT_ID`, `VITE_COGNITO_REDIRECT_SIGN_IN`, and
+  `VITE_COGNITO_REDIRECT_SIGN_OUT`: Cognito configuration for Amplify auth.
+
+Leave Cognito values blank or unset when auth should be disabled. Missing or
+invalid Cognito settings are treated as auth disabled so the public demo does not
+expose a real user pool.
+
+## Local Development
+
+Start the Vite development server:
 
 ```shell
 yarn dev
 ```
+
+Start Storybook:
+
+```shell
+yarn storybook
+```
+
+or:
+
+```shell
+yarn sb
+```
+
+## Validation
+
+Run the same categories of checks used by CI:
+
+```shell
+yarn lint
+yarn test
+yarn build
+```
+
+Install Playwright's Chromium browser before the first local E2E run:
+
+```shell
+yarn test:e2e:install
+yarn test:e2e
+```
+
+For headed E2E debugging:
+
+```shell
+yarn test:e2e:headed
+```
+
+Build Storybook before changing shared UI or stories:
+
+```shell
+yarn build-storybook
+```
+
+CI runs `yarn install --immutable`, installs Playwright Chromium, runs
+`yarn ci`, runs `yarn test:e2e`, builds the app, and runs semantic-release on
+pushes to `main`.
+
+## Build, Release, And Deploy
+
+Build the production app:
+
+```shell
+yarn build
+```
+
+Release automation runs only on pushes to `main`. The release job uses
+semantic-release with conventional commits, writes release notes/changelog
+metadata, creates GitHub releases, and keeps npm publishing disabled.
+
+The GitHub Pages deployment job uses the built `dist` artifact after the release
+job succeeds.
 
 ## GitHub Pages Demo
 
@@ -111,9 +157,12 @@ The demo app deploys to GitHub Pages at:
 https://aquia-inc.github.io/template-vite-react/
 ```
 
-GitHub Pages must be configured in the repository settings with **Build and deployment** source set to **GitHub Actions**.
+GitHub Pages must be configured in the repository settings with **Build and
+deployment** source set to **GitHub Actions**.
 
-The CI/CD workflow deploys on every push to `main` after the existing lint, unit test, Playwright, build, and semantic-release steps complete. Pull requests keep the local `/` base path and do not deploy.
+The CI/CD workflow deploys on every push to `main` after lint, unit test,
+Playwright, build, and semantic-release steps complete. Pull requests keep the
+local `/` base path and do not deploy.
 
 The Pages build uses these public environment values:
 
@@ -123,6 +172,13 @@ VITE_CF_DOMAIN=https://aquia-inc.github.io/template-vite-react/
 VITE_IDP_ENABLED=false
 ```
 
-Leave the Cognito environment values blank or unset for the public demo. The app treats missing or invalid Cognito settings as auth disabled, so the Pages demo does not expose a real user pool.
+Leave the Cognito environment values blank or unset for the public demo. For
+project Pages, Vite builds assets under `/template-vite-react/` and React Router
+uses the matching basename. The workflow also copies `dist/index.html` to
+`dist/404.html` so direct visits to client-side routes can load the SPA fallback.
 
-For project Pages, Vite builds assets under `/template-vite-react/` and React Router uses the matching basename. The workflow also copies `dist/index.html` to `dist/404.html` so direct visits to client-side routes can load the SPA fallback.
+## Dependency And Security Triage
+
+See `docs/dependency-security-triage.md` for the current audit/outdated surface
+and recommended follow-up PRs. Keep dependency manifest and lockfile changes in
+separate, focused PRs so validation and rollback stay clear.

--- a/docs/dependency-security-triage.md
+++ b/docs/dependency-security-triage.md
@@ -1,0 +1,82 @@
+# Dependency And Security Triage
+
+This note captures the current dependency/security surface on `origin/main` as
+of 2026-05-13 at commit `4616531`.
+
+## Commands Run
+
+```shell
+mise exec node@24 -- yarn install --immutable
+mise exec node@24 -- yarn npm audit --recursive --severity moderate --json
+mise exec node@24 -- yarn outdated --json
+mise exec node@24 -- yarn why node-gyp
+mise exec node@24 -- yarn why tar
+mise exec node@24 -- yarn why minimatch
+mise exec node@24 -- yarn why glob
+mise exec node@24 -- yarn why ajv
+mise exec node@24 -- yarn why @types/testing-library__jest-dom
+mise exec node@24 -- yarn why @types/uuid
+mise exec node@24 -- yarn why filelist
+mise exec node@24 -- yarn why whatwg-encoding
+```
+
+## Summary
+
+- `yarn install --immutable` succeeds with existing peer warnings.
+- `yarn outdated --json` reports only `@types/node`: current `24.12.4`, latest
+  `25.7.0`.
+- `yarn npm audit --recursive --severity moderate --json` reports direct stub
+  type package deprecations plus transitive tooling advisories/deprecations.
+
+## Recommended Follow-Up PRs
+
+### Actionable
+
+1. Remove direct stub type packages:
+   - `@types/testing-library__jest-dom@6.0.0` is a deprecated stub because
+     `@testing-library/jest-dom` ships its own types.
+   - `@types/uuid@11.0.0` is a deprecated stub because `uuid` ships its own
+     types.
+   - Validate with `yarn install --immutable`, `yarn lint`, `yarn test`, and
+     `yarn build`.
+
+2. Track or update the commitlint AJV path:
+   - audit reports `ajv@8.12.0` through
+     `@commitlint/config-validator@21.0.1`.
+   - This should be handled by a focused commitlint/tooling PR when an upstream
+     package update removes the affected AJV version, or by an explicitly tested
+     Yarn resolution if maintainers accept that tradeoff.
+
+3. Review native-build tooling transitive dependencies:
+   - audit reports `tar@6.2.1`, `npmlog@6.0.2`, `gauge@4.0.4`,
+     `are-we-there-yet@3.0.1`, and `rimraf@3.0.2` through `node-gyp@9.4.0`.
+   - `yarn why node-gyp` shows `node-gyp@9.4.0` coming from optional/native
+     tooling paths including `@parcel/watcher`, `fsevents`, and `node-addon-api`.
+   - Treat this as a tooling-chain follow-up, not an application runtime issue.
+
+### Upstream Or Unavoidable For Now
+
+1. Keep `@types/node` on the Node 24 line:
+   - `yarn outdated --json` reports latest `@types/node@25.7.0`, but the repo
+     runtime is Node 24 in `.nvmrc`, `package.json`, and CI.
+   - Do not move to Node 25 typings until the runtime pin changes.
+
+2. Track Jest/jsdom transitive deprecations:
+   - `glob@10.5.0` is pulled by Jest 30 packages, including `@jest/reporters`,
+     `jest-config`, and `jest-runtime`.
+   - `whatwg-encoding@3.1.1` is pulled through `jsdom@26.1.0`.
+   - Avoid broad overrides unless Jest/jsdom validation is isolated and complete.
+
+3. Track `minimatch` through transitive tooling:
+   - vulnerable `minimatch@5.1.6` is pulled through `filelist@1.0.4`.
+   - vulnerable `minimatch@9.0.5` is pulled through `glob@10.5.0`.
+   - non-vulnerable `minimatch@10.2.5` is already present through newer ESLint,
+     npm, TypeScript ESLint, and related tooling.
+
+## Rollback Notes
+
+Dependency/security follow-ups should be split by ownership area. Avoid bundling
+stub type removal, commitlint/AJV changes, native build chain updates, and
+Jest/jsdom overrides into one PR. If a follow-up causes validation failures,
+revert only that focused PR and leave docs and unrelated dependency updates in
+place.


### PR DESCRIPTION
## Summary

Refresh the template documentation so contributors have current setup, validation, auth, release, and dependency/security triage guidance.

### Added

- Added `docs/dependency-security-triage.md` with current `yarn npm audit`, `yarn outdated`, and `yarn why` evidence.
- Added follow-up recommendations for direct stub type package removal, commitlint/AJV tracking, native build tooling advisories, and upstream Jest/jsdom/glob/minimatch items.

### Changed

- Updated `README.md` for Node 24, Yarn 4.14.1, local env/auth setup, Storybook, test/build commands, semantic-release, and GitHub Pages behavior.
- Replaced generic `CONTRIBUTING.md` placeholder content with template-specific branch, validation, dependency, docs, and PR guidance.

### Deprecated

- None.

### Removed

- Removed stale placeholder contributor text and the old `aquia/template-vite-react` clone URL.

### Fixed

- Fixed documentation drift around repo ownership, package manager/runtime pins, and local setup flow.

## How to test

- `mise exec node@24 -- yarn install --immutable`
- `mise exec node@24 -- yarn npm audit --recursive --severity moderate --json`
- `mise exec node@24 -- yarn outdated --json`
- `mise exec node@24 -- yarn lint`
