### PR TITLE
feat(auth): add demo auth mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 # App
 VITE_PUBLIC_BASE_PATH='/'
+VITE_DEMO_AUTH_ENABLED='false'
 VITE_IDP_ENABLED='false'
 
 # AWS
@@ -18,6 +19,7 @@ VITE_COGNITO_REDIRECT_SIGN_OUT='http://localhost:3000/signout'
 # GitHub Pages demo builds use:
 # VITE_PUBLIC_BASE_PATH='/template-vite-react/'
 # VITE_CF_DOMAIN='https://aquia-inc.github.io/template-vite-react/'
+# VITE_DEMO_AUTH_ENABLED='true'
 # VITE_IDP_ENABLED='false'
 #
 # Leave Cognito values blank or unset for the public demo so auth remains

--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,7 @@ VITE_COGNITO_REDIRECT_SIGN_OUT='http://localhost:3000/signout'
 # VITE_DEMO_AUTH_ENABLED='true'
 # VITE_IDP_ENABLED='false'
 #
-# Leave Cognito values blank or unset for the public demo so auth remains
-# disabled and no real user pool is exposed.
+# Leave Cognito values blank or unset for local/GitHub Pages demo builds so
+# Cognito auth remains disabled and no real user pool is exposed.
+# Demo auth is enabled only when VITE_DEMO_AUTH_ENABLED='true'.
+# Do not enable demo auth in production.

--- a/config/jest/configMock.ts
+++ b/config/jest/configMock.ts
@@ -2,6 +2,7 @@ import { createAppConfig } from '@/utils/appConfig'
 
 const CONFIG = createAppConfig({
   VITE_CF_DOMAIN: process.env.VITE_CF_DOMAIN ?? 'https://localhost:3000/',
+  VITE_DEMO_AUTH_ENABLED: process.env.VITE_DEMO_AUTH_ENABLED ?? 'false',
   VITE_PUBLIC_BASE_PATH: process.env.VITE_PUBLIC_BASE_PATH ?? '/',
   ...process.env,
 })

--- a/src/actions/loginUser.demo.test.tsx
+++ b/src/actions/loginUser.demo.test.tsx
@@ -1,0 +1,46 @@
+import { signIn } from 'aws-amplify/auth'
+import { AuthActions } from '@/actions/actionTypes'
+import loginUser from '@/actions/loginUser'
+import { getDemoAuthSession } from '@/utils/demoAuth'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  window.localStorage.clear()
+})
+
+test('signs in a demo user without calling Amplify signIn', async () => {
+  const dispatch = jest.fn()
+  const payload = { email: 'reviewer@example.com', password: 'password' }
+
+  const data = await loginUser(dispatch, payload)
+
+  expect(signIn).not.toHaveBeenCalled()
+  expect(data).toEqual({
+    jwtToken: 'demo-auth-token',
+    username: 'reviewer',
+    email: payload.email,
+  })
+  expect(getDemoAuthSession()).toEqual(data)
+  expect(dispatch).toHaveBeenCalledWith({ type: AuthActions.LOGIN_REQUEST })
+  expect(dispatch).toHaveBeenCalledWith({
+    type: AuthActions.LOGIN_SUCCESS,
+    payload: data,
+  })
+})

--- a/src/actions/loginUser.demo.test.tsx
+++ b/src/actions/loginUser.demo.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@/utils/config', () => {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  window.localStorage.clear()
+  window.sessionStorage.clear()
 })
 
 test('signs in a demo user without calling Amplify signIn', async () => {

--- a/src/actions/loginUser.tsx
+++ b/src/actions/loginUser.tsx
@@ -12,6 +12,8 @@ import {
 import { AuthActions } from '@/actions/actionTypes'
 import { LoginParams } from '@/hooks/types'
 import { AuthActionParams } from '@/store/auth/types'
+import CONFIG from '@/utils/config'
+import { createDemoAuthState, saveDemoAuthSession } from '@/utils/demoAuth'
 
 type UserData = {
   jwtToken: string
@@ -25,6 +27,15 @@ export default async function loginUser(
 ): Promise<UserData | undefined> {
   try {
     dispatch({ type: AuthActions.LOGIN_REQUEST })
+
+    if (CONFIG.DEMO_AUTH_ENABLED) {
+      const data = createDemoAuthState(payload.email) as UserData
+      saveDemoAuthSession(data)
+      dispatch({ type: AuthActions.LOGIN_SUCCESS, payload: data })
+
+      return data
+    }
+
     const signInResult = await signIn({
       username: payload.email,
       password: payload.password,

--- a/src/actions/logoutUser.demo.test.tsx
+++ b/src/actions/logoutUser.demo.test.tsx
@@ -26,7 +26,7 @@ jest.mock('@/utils/config', () => {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  window.localStorage.clear()
+  window.sessionStorage.clear()
 })
 
 test('clears demo auth state without calling Amplify signOut', async () => {

--- a/src/actions/logoutUser.demo.test.tsx
+++ b/src/actions/logoutUser.demo.test.tsx
@@ -1,0 +1,41 @@
+import { signOut } from 'aws-amplify/auth'
+import { AuthActions } from '@/actions/actionTypes'
+import logoutUser from '@/actions/logoutUser'
+import {
+  createDemoAuthState,
+  getDemoAuthSession,
+  saveDemoAuthSession,
+} from '@/utils/demoAuth'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  window.localStorage.clear()
+})
+
+test('clears demo auth state without calling Amplify signOut', async () => {
+  const dispatch = jest.fn()
+  saveDemoAuthSession(createDemoAuthState('reviewer@example.com'))
+
+  await logoutUser(dispatch)
+
+  expect(signOut).not.toHaveBeenCalled()
+  expect(getDemoAuthSession()).toBeNull()
+  expect(dispatch).toHaveBeenCalledWith({ type: AuthActions.LOGOUT })
+})

--- a/src/actions/logoutUser.tsx
+++ b/src/actions/logoutUser.tsx
@@ -5,10 +5,17 @@
 import { signOut } from 'aws-amplify/auth'
 import { AuthActions } from '@/actions/actionTypes'
 import { AuthActionParams } from '@/store/auth/types'
+import CONFIG from '@/utils/config'
+import { clearDemoAuthSession } from '@/utils/demoAuth'
 
 export default async function logoutUser(
   dispatch: React.Dispatch<AuthActionParams>,
 ) {
-  await signOut()
+  if (CONFIG.DEMO_AUTH_ENABLED) {
+    clearDemoAuthSession()
+  } else {
+    await signOut()
+  }
+
   dispatch({ type: AuthActions.LOGOUT })
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -14,6 +14,12 @@ export const AUTH_DISABLED_MESSAGE = 'Authentication is currently disabled.'
 export const AUTH_DISABLED_HELP =
   'Provide valid Cognito environment variables to enable the sign-in experience.'
 
+export const DEMO_AUTH_MESSAGE =
+  'Demo auth mode is enabled for local and public review.'
+
+export const DEMO_AUTH_HELP =
+  'Demo auth mode is enabled. Any valid email and password will open the demo app.'
+
 export const SIGN_IN_CTA = 'Sign In'
 
 export const SIGN_IN_CTA_IDP = 'Login with IDP'

--- a/src/router/authDisabledLoaders.test.ts
+++ b/src/router/authDisabledLoaders.test.ts
@@ -1,0 +1,32 @@
+import { Routes } from '@/router/constants'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'false',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+test('redirects protected routes home when auth is disabled', async () => {
+  const authLoader = (await import('@/router/authLoader')).default
+  const response = await authLoader()
+
+  expect(response).toBeInstanceOf(Response)
+  expect(response?.headers.get('Location')).toBe(Routes.HOME)
+})
+
+test('does not redirect home route when auth is disabled', async () => {
+  const homeLoader = (await import('@/router/homeLoader')).default
+
+  await expect(homeLoader()).resolves.toBeNull()
+})

--- a/src/router/demoLoaders.test.ts
+++ b/src/router/demoLoaders.test.ts
@@ -1,0 +1,48 @@
+import { Routes } from '@/router/constants'
+import { createDemoAuthState, saveDemoAuthSession } from '@/utils/demoAuth'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+test('allows a demo auth session to access protected routes', async () => {
+  const authLoader = (await import('@/router/authLoader')).default
+  saveDemoAuthSession(createDemoAuthState('reviewer@example.com'))
+
+  await expect(authLoader()).resolves.toBeNull()
+})
+
+test('redirects protected routes to login when demo auth has no session', async () => {
+  const authLoader = (await import('@/router/authLoader')).default
+  const response = await authLoader()
+
+  expect(response).toBeInstanceOf(Response)
+  expect(response?.headers.get('Location')).toBe(Routes.AUTH_LOGIN)
+})
+
+test('redirects demo auth users away from the home route to the dashboard', async () => {
+  const homeLoader = (await import('@/router/homeLoader')).default
+  saveDemoAuthSession(createDemoAuthState('reviewer@example.com'))
+
+  const response = await homeLoader()
+
+  expect(response).toBeInstanceOf(Response)
+  expect(response?.headers.get('Location')).toBe(Routes.DASHBOARD)
+})

--- a/src/router/demoLoaders.test.ts
+++ b/src/router/demoLoaders.test.ts
@@ -19,7 +19,7 @@ jest.mock('@/utils/config', () => {
 })
 
 beforeEach(() => {
-  window.localStorage.clear()
+  window.sessionStorage.clear()
 })
 
 test('allows a demo auth session to access protected routes', async () => {

--- a/src/store/auth/AuthProvider.demo.test.tsx
+++ b/src/store/auth/AuthProvider.demo.test.tsx
@@ -39,7 +39,7 @@ const StateSnapshot = () => (
 
 beforeEach(() => {
   jest.clearAllMocks()
-  window.localStorage.clear()
+  window.sessionStorage.clear()
   ;(useLocation as jest.Mock).mockReturnValue({ pathname: '/app' })
   ;(useMatch as jest.Mock).mockReturnValue({ path: '/app' })
   ;(useNavigate as jest.Mock).mockReturnValue(jest.fn())

--- a/src/store/auth/AuthProvider.demo.test.tsx
+++ b/src/store/auth/AuthProvider.demo.test.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth'
+import { useLocation, useMatch, useNavigate } from 'react-router-dom'
+import AuthProvider from '@/store/auth/AuthProvider'
+import AuthStateContext from '@/store/auth/AuthStateContext'
+import { AuthState } from '@/store/auth/types'
+import { createDemoAuthState, saveDemoAuthSession } from '@/utils/demoAuth'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+  useMatch: jest.fn(),
+  useNavigate: jest.fn(),
+}))
+
+const StateSnapshot = () => (
+  <AuthStateContext.Consumer>
+    {(state: AuthState) => (
+      <output data-testid="auth-state">{JSON.stringify(state)}</output>
+    )}
+  </AuthStateContext.Consumer>
+)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  window.localStorage.clear()
+  ;(useLocation as jest.Mock).mockReturnValue({ pathname: '/app' })
+  ;(useMatch as jest.Mock).mockReturnValue({ path: '/app' })
+  ;(useNavigate as jest.Mock).mockReturnValue(jest.fn())
+})
+
+test('initializes auth state from a demo auth session without Amplify calls', async () => {
+  const demoState = createDemoAuthState('reviewer@example.com')
+  saveDemoAuthSession(demoState)
+
+  await act(async () => {
+    render(
+      <AuthProvider>
+        <StateSnapshot />
+      </AuthProvider>,
+    )
+  })
+
+  await waitFor(() => {
+    expect(
+      JSON.parse(screen.getByTestId('auth-state').textContent ?? ''),
+    ).toEqual({
+      ...demoState,
+      error: null,
+    })
+    expect(fetchAuthSession).not.toHaveBeenCalled()
+    expect(getCurrentUser).not.toHaveBeenCalled()
+  })
+})

--- a/src/store/auth/AuthProvider.tsx
+++ b/src/store/auth/AuthProvider.tsx
@@ -16,6 +16,7 @@ import AuthDispatchContext from '@/store/auth/AuthDispatchContext'
 import AuthStateContext from '@/store/auth/AuthStateContext'
 import { Routes } from '@/router/constants'
 import CONFIG from '@/utils/config'
+import { getDemoAuthSession } from '@/utils/demoAuth'
 
 /**
  * The AuthContextProvider is used to provide user data to components.
@@ -38,6 +39,19 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
    */
   useEffect(() => {
     if (!CONFIG.AUTH_ENABLED) {
+      return
+    }
+
+    if (CONFIG.DEMO_AUTH_ENABLED) {
+      const demoSession = getDemoAuthSession()
+
+      if (demoSession) {
+        dispatch({
+          type: AuthActions.LOGIN_SUCCESS,
+          payload: demoSession,
+        })
+      }
+
       return
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export type AppConfig = {
 
 export type AppFeatureFlags = {
   AUTH_ENABLED: boolean
+  COGNITO_AUTH_ENABLED: boolean
+  DEMO_AUTH_ENABLED: boolean
   IDP_ENABLED: boolean
 }
 

--- a/src/utils/appConfig.test.ts
+++ b/src/utils/appConfig.test.ts
@@ -59,3 +59,19 @@ test('prefers real Cognito auth when both Cognito and demo auth are configured',
   expect(config.DEMO_AUTH_ENABLED).toBe(false)
   expect(config.AUTH_ENABLED).toBe(true)
 })
+
+test('keeps demo auth disabled when Cognito config is partially set and invalid', () => {
+  const config = createAppConfig({
+    VITE_DEMO_AUTH_ENABLED: 'true',
+    VITE_AWS_REGION: 'us-east-1',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(config.COGNITO_AUTH_ENABLED).toBe(false)
+  expect(config.DEMO_AUTH_ENABLED).toBe(false)
+  expect(config.AUTH_ENABLED).toBe(false)
+})

--- a/src/utils/appConfig.test.ts
+++ b/src/utils/appConfig.test.ts
@@ -1,0 +1,61 @@
+import { createAppConfig } from '@/utils/appConfig'
+
+const validCognitoEnv = {
+  VITE_AWS_REGION: 'us-east-1',
+  VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
+  VITE_COGNITO_REDIRECT_SIGN_IN: 'https://localhost:3000/auth/login',
+  VITE_COGNITO_REDIRECT_SIGN_OUT: 'https://localhost:3000/auth/logout',
+  VITE_USER_POOL_CLIENT_ID: '1234567890123456789012',
+  VITE_USER_POOL_ID: 'us-east-1_123456789',
+}
+
+test('enables real Cognito auth when Cognito config is valid', () => {
+  const config = createAppConfig(validCognitoEnv)
+
+  expect(config.COGNITO_AUTH_ENABLED).toBe(true)
+  expect(config.DEMO_AUTH_ENABLED).toBe(false)
+  expect(config.AUTH_ENABLED).toBe(true)
+})
+
+test('enables demo auth when requested and Cognito config is blank', () => {
+  const config = createAppConfig({
+    VITE_DEMO_AUTH_ENABLED: 'true',
+    VITE_AWS_REGION: '',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(config.COGNITO_AUTH_ENABLED).toBe(false)
+  expect(config.DEMO_AUTH_ENABLED).toBe(true)
+  expect(config.AUTH_ENABLED).toBe(true)
+})
+
+test('keeps auth disabled when Cognito and demo auth are both unavailable', () => {
+  const config = createAppConfig({
+    VITE_DEMO_AUTH_ENABLED: 'false',
+    VITE_AWS_REGION: '',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(config.COGNITO_AUTH_ENABLED).toBe(false)
+  expect(config.DEMO_AUTH_ENABLED).toBe(false)
+  expect(config.AUTH_ENABLED).toBe(false)
+})
+
+test('prefers real Cognito auth when both Cognito and demo auth are configured', () => {
+  const config = createAppConfig({
+    ...validCognitoEnv,
+    VITE_DEMO_AUTH_ENABLED: 'true',
+  })
+
+  expect(config.COGNITO_AUTH_ENABLED).toBe(true)
+  expect(config.DEMO_AUTH_ENABLED).toBe(false)
+  expect(config.AUTH_ENABLED).toBe(true)
+})

--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -28,6 +28,15 @@ export const buildApiUrl = (cfDomain: string) => {
   }
 }
 
+const areCognitoConfigValuesBlank = (authConfig: {
+  AWS_REGION: string
+  COGNITO_DOMAIN: string
+  COGNITO_REDIRECT_SIGN_IN: string
+  COGNITO_REDIRECT_SIGN_OUT: string
+  USER_POOL_CLIENT_ID: string
+  USER_POOL_ID: string
+}) => Object.values(authConfig).every((value) => value.trim() === '')
+
 export const createAppConfig = (env: AppConfigEnv): AppConfig => {
   const cfDomain = env.VITE_CF_DOMAIN ?? ''
   const authConfig = {
@@ -40,7 +49,9 @@ export const createAppConfig = (env: AppConfigEnv): AppConfig => {
   }
   const cognitoAuthEnabled = isCognitoConfigValid(authConfig)
   const demoAuthEnabled =
-    !cognitoAuthEnabled && readBooleanEnv(env.VITE_DEMO_AUTH_ENABLED)
+    !cognitoAuthEnabled &&
+    areCognitoConfigValuesBlank(authConfig) &&
+    readBooleanEnv(env.VITE_DEMO_AUTH_ENABLED)
 
   return {
     //* AWS configuration

--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -7,6 +7,7 @@ type AppConfigEnv = {
   VITE_COGNITO_DOMAIN?: string
   VITE_COGNITO_REDIRECT_SIGN_IN?: string
   VITE_COGNITO_REDIRECT_SIGN_OUT?: string
+  VITE_DEMO_AUTH_ENABLED?: string
   VITE_IDP_ENABLED?: string
   VITE_PUBLIC_BASE_PATH?: string
   VITE_USER_POOL_CLIENT_ID?: string
@@ -37,6 +38,9 @@ export const createAppConfig = (env: AppConfigEnv): AppConfig => {
     USER_POOL_CLIENT_ID: env.VITE_USER_POOL_CLIENT_ID ?? '',
     USER_POOL_ID: env.VITE_USER_POOL_ID ?? '',
   }
+  const cognitoAuthEnabled = isCognitoConfigValid(authConfig)
+  const demoAuthEnabled =
+    !cognitoAuthEnabled && readBooleanEnv(env.VITE_DEMO_AUTH_ENABLED)
 
   return {
     //* AWS configuration
@@ -51,7 +55,9 @@ export const createAppConfig = (env: AppConfigEnv): AppConfig => {
     USER_POOL_ID: authConfig.USER_POOL_ID,
 
     //* Feature flags
-    AUTH_ENABLED: isCognitoConfigValid(authConfig),
+    AUTH_ENABLED: cognitoAuthEnabled || demoAuthEnabled,
+    COGNITO_AUTH_ENABLED: cognitoAuthEnabled,
+    DEMO_AUTH_ENABLED: demoAuthEnabled,
     IDP_ENABLED: readBooleanEnv(env.VITE_IDP_ENABLED),
   }
 }

--- a/src/utils/configureCognito.ts
+++ b/src/utils/configureCognito.ts
@@ -7,7 +7,7 @@ import { Amplify } from 'aws-amplify'
 import CONFIG from '@/utils/config'
 
 function configureCognito(): null {
-  if (!CONFIG.AUTH_ENABLED) {
+  if (!CONFIG.COGNITO_AUTH_ENABLED) {
     return null
   }
 

--- a/src/utils/demoAuth.test.ts
+++ b/src/utils/demoAuth.test.ts
@@ -1,0 +1,28 @@
+import {
+  clearDemoAuthSession,
+  createDemoAuthState,
+  getDemoAuthSession,
+  saveDemoAuthSession,
+} from '@/utils/demoAuth'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+test('creates a deterministic demo auth state from an email address', () => {
+  expect(createDemoAuthState('reviewer@example.com')).toEqual({
+    jwtToken: 'demo-auth-token',
+    username: 'reviewer',
+    email: 'reviewer@example.com',
+  })
+})
+
+test('persists and clears a demo auth session', () => {
+  const state = createDemoAuthState('reviewer@example.com')
+
+  saveDemoAuthSession(state)
+  expect(getDemoAuthSession()).toEqual(state)
+
+  clearDemoAuthSession()
+  expect(getDemoAuthSession()).toBeNull()
+})

--- a/src/utils/demoAuth.test.ts
+++ b/src/utils/demoAuth.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@/utils/demoAuth'
 
 beforeEach(() => {
-  window.localStorage.clear()
+  window.sessionStorage.clear()
 })
 
 test('creates a deterministic demo auth state from an email address', () => {

--- a/src/utils/demoAuth.test.ts
+++ b/src/utils/demoAuth.test.ts
@@ -26,3 +26,27 @@ test('persists and clears a demo auth session', () => {
   clearDemoAuthSession()
   expect(getDemoAuthSession()).toBeNull()
 })
+
+test('clears invalid JSON demo session data', () => {
+  window.sessionStorage.setItem(
+    'template-vite-react:demo-auth-session',
+    'invalid-json',
+  )
+
+  expect(getDemoAuthSession()).toBeNull()
+  expect(
+    window.sessionStorage.getItem('template-vite-react:demo-auth-session'),
+  ).toBeNull()
+})
+
+test('clears invalid demo session shapes', () => {
+  window.sessionStorage.setItem(
+    'template-vite-react:demo-auth-session',
+    JSON.stringify({ jwtToken: 'demo-auth-token' }),
+  )
+
+  expect(getDemoAuthSession()).toBeNull()
+  expect(
+    window.sessionStorage.getItem('template-vite-react:demo-auth-session'),
+  ).toBeNull()
+})

--- a/src/utils/demoAuth.ts
+++ b/src/utils/demoAuth.ts
@@ -1,0 +1,56 @@
+import { AuthState } from '@/store/auth/types'
+
+const DEMO_AUTH_STORAGE_KEY = 'template-vite-react:demo-auth-session'
+const DEMO_AUTH_TOKEN = 'demo-auth-token'
+const DEFAULT_DEMO_EMAIL = 'demo@example.com'
+
+const getStorage = (): Storage | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  return window.localStorage
+}
+
+const isDemoAuthState = (value: unknown): value is AuthState =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as AuthState).jwtToken === 'string' &&
+  typeof (value as AuthState).username === 'string' &&
+  typeof (value as AuthState).email === 'string'
+
+export const createDemoAuthState = (email = DEFAULT_DEMO_EMAIL): AuthState => {
+  const trimmedEmail = email.trim() || DEFAULT_DEMO_EMAIL
+  const username = trimmedEmail.split('@')[0] || 'demo'
+
+  return {
+    jwtToken: DEMO_AUTH_TOKEN,
+    username,
+    email: trimmedEmail,
+  }
+}
+
+export const getDemoAuthSession = (): AuthState | null => {
+  const storage = getStorage()
+  const rawSession = storage?.getItem(DEMO_AUTH_STORAGE_KEY)
+
+  if (!rawSession) {
+    return null
+  }
+
+  try {
+    const parsedSession = JSON.parse(rawSession)
+
+    return isDemoAuthState(parsedSession) ? parsedSession : null
+  } catch {
+    return null
+  }
+}
+
+export const saveDemoAuthSession = (state: AuthState) => {
+  getStorage()?.setItem(DEMO_AUTH_STORAGE_KEY, JSON.stringify(state))
+}
+
+export const clearDemoAuthSession = () => {
+  getStorage()?.removeItem(DEMO_AUTH_STORAGE_KEY)
+}

--- a/src/utils/demoAuth.ts
+++ b/src/utils/demoAuth.ts
@@ -9,7 +9,7 @@ const getStorage = (): Storage | undefined => {
     return undefined
   }
 
-  return window.localStorage
+  return window.sessionStorage
 }
 
 const isDemoAuthState = (value: unknown): value is AuthState =>

--- a/src/utils/demoAuth.ts
+++ b/src/utils/demoAuth.ts
@@ -41,10 +41,15 @@ export const getDemoAuthSession = (): AuthState | null => {
   try {
     const parsedSession = JSON.parse(rawSession)
 
-    return isDemoAuthState(parsedSession) ? parsedSession : null
+    if (isDemoAuthState(parsedSession)) {
+      return parsedSession
+    }
   } catch {
-    return null
+    // Fall through to clear corrupted demo session data.
   }
+
+  storage?.removeItem(DEMO_AUTH_STORAGE_KEY)
+  return null
 }
 
 export const saveDemoAuthSession = (state: AuthState) => {

--- a/src/utils/getJWT.ts
+++ b/src/utils/getJWT.ts
@@ -4,12 +4,24 @@
  */
 import { fetchAuthSession } from 'aws-amplify/auth'
 import AuthError from '@/errors/AuthError'
+import CONFIG from '@/utils/config'
+import { getDemoAuthSession } from '@/utils/demoAuth'
 
 /**
  * Get the Cognito JWT Token from the current session.
  * @returns {Promise<string>} The Cognito JWT Token.
  */
 const getJWT = async (): Promise<string> => {
+  if (CONFIG.DEMO_AUTH_ENABLED) {
+    const jwtToken = getDemoAuthSession()?.jwtToken
+
+    if (!jwtToken) {
+      throw new AuthError().toResponse()
+    }
+
+    return jwtToken
+  }
+
   const session = await fetchAuthSession()
   const jwtToken = session.tokens?.accessToken?.toString()
 

--- a/src/views/Dashboard/Dashboard.loader.demo.test.ts
+++ b/src/views/Dashboard/Dashboard.loader.demo.test.ts
@@ -1,0 +1,32 @@
+import { getCurrentUser } from 'aws-amplify/auth'
+import dashboardLoader from '@/views/Dashboard/Dashboard.loader'
+import { createDemoAuthState, saveDemoAuthSession } from '@/utils/demoAuth'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  window.localStorage.clear()
+})
+
+test('returns the demo username without calling Amplify', async () => {
+  saveDemoAuthSession(createDemoAuthState('reviewer@example.com'))
+
+  await expect(dashboardLoader()).resolves.toEqual({ username: 'reviewer' })
+  expect(getCurrentUser).not.toHaveBeenCalled()
+})

--- a/src/views/Dashboard/Dashboard.loader.demo.test.ts
+++ b/src/views/Dashboard/Dashboard.loader.demo.test.ts
@@ -21,7 +21,7 @@ jest.mock('@/utils/config', () => {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  window.localStorage.clear()
+  window.sessionStorage.clear()
 })
 
 test('returns the demo username without calling Amplify', async () => {

--- a/src/views/Dashboard/Dashboard.loader.ts
+++ b/src/views/Dashboard/Dashboard.loader.ts
@@ -4,8 +4,16 @@
  * @see {@link dashboard/Routes}
  */
 import { getCurrentUser } from 'aws-amplify/auth'
+import CONFIG from '@/utils/config'
+import { getDemoAuthSession } from '@/utils/demoAuth'
 
 const dashboardLoader = async (): Promise<{ username: string }> => {
+  if (CONFIG.DEMO_AUTH_ENABLED) {
+    return {
+      username: getDemoAuthSession()?.username ?? '',
+    }
+  }
+
   const userInfo = await getCurrentUser()
 
   return {

--- a/src/views/SignIn/SignIn.demo.test.tsx
+++ b/src/views/SignIn/SignIn.demo.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SignIn from '@/views/SignIn/SignIn'
+
+jest.mock('@/utils/config', () => {
+  const { createAppConfig } = jest.requireActual('@/utils/appConfig')
+
+  return {
+    __esModule: true,
+    default: createAppConfig({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+  }
+})
+
+test('clearly indicates demo auth mode on the sign-in page', () => {
+  render(
+    <MemoryRouter>
+      <SignIn />
+    </MemoryRouter>,
+  )
+
+  expect(
+    screen.getByText(
+      /demo auth mode is enabled\. any valid email and password will open the demo app\./i,
+    ),
+  ).toBeInTheDocument()
+})

--- a/src/views/SignIn/SignIn.demo.test.tsx
+++ b/src/views/SignIn/SignIn.demo.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@/utils/config', () => {
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
       VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_IDP_ENABLED: 'true',
       VITE_USER_POOL_CLIENT_ID: '',
       VITE_USER_POOL_ID: '',
     }),
@@ -31,4 +32,5 @@ test('clearly indicates demo auth mode on the sign-in page', () => {
       /demo auth mode is enabled\. any valid email and password will open the demo app\./i,
     ),
   ).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /login with idp/i })).toBeNull()
 })

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -29,6 +29,8 @@ import { TContext, TFieldValues } from '@/views/SignIn/SignIn.interfaces'
 import {
   AUTH_DISABLED_HELP,
   AUTH_DISABLED_MESSAGE,
+  DEMO_AUTH_HELP,
+  DEMO_AUTH_MESSAGE,
   PUBLIC_APP_NAME,
   SIGN_IN_CTA,
   SIGN_IN_CTA_IDP,
@@ -80,6 +82,9 @@ const SignInForm: React.FC = () => {
       spacing={3}
     >
       {!authEnabled && <Alert severity="warning">{AUTH_DISABLED_HELP}</Alert>}
+      {CONFIG.DEMO_AUTH_ENABLED && (
+        <Alert severity="info">{DEMO_AUTH_HELP}</Alert>
+      )}
       <InputFormControl<TFieldValues, TContext>
         control={control}
         name="email"
@@ -142,7 +147,9 @@ const SignIn = (): JSX.Element => {
   const { breakpoints } = useTheme()
   const hidden = useMediaQuery(breakpoints.down('md'))
   const directions = CONFIG.AUTH_ENABLED
-    ? SIGN_IN_DIRECTIONS
+    ? CONFIG.DEMO_AUTH_ENABLED
+      ? DEMO_AUTH_MESSAGE
+      : SIGN_IN_DIRECTIONS
     : AUTH_DISABLED_MESSAGE
 
   return (

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -119,7 +119,7 @@ const SignInForm: React.FC = () => {
         {SIGN_IN_CTA}
       </SubmitButton>
       <LoadingIcon />
-      {CONFIG.IDP_ENABLED && (
+      {CONFIG.COGNITO_AUTH_ENABLED && CONFIG.IDP_ENABLED && (
         <>
           <Typography align="center" variant="subtitle2">
             or...

--- a/src/views/SignIn/useSignIn.ts
+++ b/src/views/SignIn/useSignIn.ts
@@ -28,6 +28,7 @@ const useSignIn = (): useSignInReturnType => {
   const dispatch = useAuthDispatch()
   const navigate = useNavigate()
   const authEnabled = CONFIG.AUTH_ENABLED
+  const cognitoAuthEnabled = CONFIG.COGNITO_AUTH_ENABLED
 
   const [loading, setLoading] = useState<boolean>(false)
   const [showPassword, setShowPassword] = useState<boolean>(false)
@@ -72,7 +73,7 @@ const useSignIn = (): useSignInReturnType => {
   })
 
   const handleFederatedSignIn = useCallback(async () => {
-    if (!authEnabled) {
+    if (!cognitoAuthEnabled) {
       setAlert({
         message: AUTH_DISABLED_HELP_TEXT,
         severity: 'warning',
@@ -88,7 +89,7 @@ const useSignIn = (): useSignInReturnType => {
         severity: 'error',
       })
     }
-  }, [authEnabled, setAlert])
+  }, [cognitoAuthEnabled, setAlert])
 
   const onSubmit = useCallback(
     async (data: TFieldValues) => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_AWS_REGION: string
+  readonly VITE_DEMO_AUTH_ENABLED: string
   readonly VITE_IDP_ENABLED: string
   readonly VITE_COGNITO_DOMAIN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_IN: string


### PR DESCRIPTION
## Summary

Adds an explicit mock/demo auth mode for local and GitHub Pages review without requiring real Cognito secrets. Real Cognito detection remains separate and continues to take precedence when valid Cognito config is present.

### Added

- `VITE_DEMO_AUTH_ENABLED` config support for demo-only auth when Cognito env is blank/unset.
- Deterministic local demo auth session storage with demo login, logout, JWT, route-loader, dashboard-loader, and auth-provider handling.
- Focused tests for config detection, demo login/logout, route access, auth-disabled behavior, provider initialization, dashboard loader, and visible demo sign-in messaging.

### Changed

- `AUTH_ENABLED` now means either real Cognito auth is configured or demo auth is explicitly enabled.
- `COGNITO_AUTH_ENABLED` gates Amplify configuration and hosted UI redirect behavior so demo mode does not call Amplify auth APIs.
- The sign-in page shows a clear info alert when demo auth mode is active.

### Deprecated

None.

### Removed

None.

### Fixed

- Public/local demo builds can now enter protected app routes without fake Cognito values.
- Auth-disabled mode still blocks sign-in and protected route access when neither Cognito nor demo auth is configured.

## How to test

- `mise exec node@24 -- yarn test`
- `mise exec node@24 -- yarn lint`
- `mise exec node@24 -- yarn build`
- `mise exec node@24 -- yarn test:e2e`

Notes:
- Set `VITE_DEMO_AUTH_ENABLED=true` with Cognito env blank/unset for local or Pages demo review.
- Keep `VITE_DEMO_AUTH_ENABLED=false` for production Cognito deployments unless explicitly running a demo build.
- If valid Cognito config is present, real Cognito auth takes precedence over demo auth.