### PR TITLE
feat: add template adoption setup tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Dummy values for local testing to avoid errors
+# Defaults for local development without auth.
 
 # App
 VITE_PUBLIC_BASE_PATH='/'
@@ -9,12 +9,19 @@ VITE_IDP_ENABLED='false'
 VITE_AWS_REGION='us-east-1'
 VITE_CF_DOMAIN='https://localhost:3000'
 
-# AWS Cognito
-VITE_COGNITO_DOMAIN='https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abcd1234'
-VITE_USER_POOL_ID='us-east-1_abcd1234'
-VITE_USER_POOL_CLIENT_ID='12345678901234567890123456'
-VITE_COGNITO_REDIRECT_SIGN_IN='http://localhost:3000/signin'
-VITE_COGNITO_REDIRECT_SIGN_OUT='http://localhost:3000/signout'
+# AWS Cognito. Blank values mean Cognito auth is not configured.
+VITE_COGNITO_DOMAIN=''
+VITE_USER_POOL_ID=''
+VITE_USER_POOL_CLIENT_ID=''
+VITE_COGNITO_REDIRECT_SIGN_IN=''
+VITE_COGNITO_REDIRECT_SIGN_OUT=''
+
+# Sample Cognito values for local testing. Replace every value before use.
+# VITE_COGNITO_DOMAIN='https://sample.auth.us-east-1.amazoncognito.com'
+# VITE_USER_POOL_ID='us-east-1_sample123'
+# VITE_USER_POOL_CLIENT_ID='sample-client-id'
+# VITE_COGNITO_REDIRECT_SIGN_IN='http://localhost:3000/signin'
+# VITE_COGNITO_REDIRECT_SIGN_OUT='http://localhost:3000/signout'
 
 # GitHub Pages demo builds use:
 # VITE_PUBLIC_BASE_PATH='/template-vite-react/'

--- a/.env.test
+++ b/.env.test
@@ -1,12 +1,17 @@
-# Dummy values for local testing to avoid errors
+# Test defaults use the local-disabled profile unless a test overrides env.
+
+# App
+VITE_PUBLIC_BASE_PATH='/'
+VITE_DEMO_AUTH_ENABLED='false'
+VITE_IDP_ENABLED='false'
 
 # AWS
 VITE_AWS_REGION='us-east-1'
 VITE_CF_DOMAIN='https://localhost:3000'
 
 # AWS Cognito
-VITE_COGNITO_DOMAIN='https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abcd1234'
-VITE_USER_POOL_ID='us-east-1_abcd1234'
-VITE_USER_POOL_CLIENT_ID='12345678901234567890123456'
-VITE_COGNITO_REDIRECT_SIGN_IN='http://localhost:3000/signin'
-VITE_COGNITO_REDIRECT_SIGN_OUT='http://localhost:3000/signout'
+VITE_COGNITO_DOMAIN=''
+VITE_USER_POOL_ID=''
+VITE_USER_POOL_CLIENT_ID=''
+VITE_COGNITO_REDIRECT_SIGN_IN=''
+VITE_COGNITO_REDIRECT_SIGN_OUT=''

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -81,6 +81,7 @@ jobs:
         env:
           VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
           VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}
+          VITE_DEMO_AUTH_ENABLED: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           VITE_IDP_ENABLED: 'false'
 
       - name: BUILD - Storybook
@@ -88,6 +89,7 @@ jobs:
         env:
           VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
           VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}
+          VITE_DEMO_AUTH_ENABLED: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           VITE_IDP_ENABLED: 'false'
 
       - name: UPLOAD - build artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,23 @@ Use the pinned runtime and package manager:
 nvm use
 corepack enable
 yarn install --immutable
+yarn setup
+yarn doctor
+```
+
+`yarn setup` verifies Node 24 and Yarn 4.14.1, creates
+`.env.development.local` from `.env.example` only when the local file is missing,
+and runs `yarn prepare` for Husky hooks. It never overwrites an existing local
+env file.
+
+`yarn doctor` reports runtime versions, local env-file presence, and the detected
+auth profile. Missing `.env.development.local` is a warning; wrong Node or Yarn
+versions fail the check. The compatibility wrapper still works when needed:
+
+```shell
 sh ./scripts/post-install.sh
 ```
 
-The post-install script creates `.env.development.local` from `.env.example`.
 Dummy Cognito values are safe for booting the app, but use real values only when
 testing auth against an owned user pool.
 
@@ -32,6 +45,7 @@ testing auth against an owned user pool.
 Run the checks that match your change. For most code changes, run:
 
 ```shell
+yarn doctor
 yarn lint
 yarn test
 yarn build
@@ -84,6 +98,7 @@ Update docs in the same PR as the behavior they describe. For docs-only changes,
 run at least:
 
 ```shell
+yarn doctor
 yarn lint
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,27 +59,38 @@ sh ./scripts/post-install.sh
 ```
 
 The post-install script copies `.env.example` to `.env.development.local`.
-Update the copied file for real Cognito values only when testing auth locally.
+The default copied file uses the `local-disabled` profile. Update it for demo
+auth or real Cognito only when needed.
 
 ## Environment And Auth
 
 The app reads public Vite environment variables from `.env*` files. Local
-development starts from `.env.example`, which includes dummy values that keep the
-app bootable.
+development starts from `.env.example`, which keeps Cognito blank by default.
+
+Profiles:
+
+| Profile          | Use when                                 | Required settings                                                                       |
+| ---------------- | ---------------------------------------- | --------------------------------------------------------------------------------------- |
+| `local-disabled` | Local dev without auth                   | Keep Cognito blank and `VITE_DEMO_AUTH_ENABLED=false`.                                  |
+| `local-demo`     | Local dev with demo auth                 | Keep Cognito blank and set `VITE_DEMO_AUTH_ENABLED=true`.                               |
+| `cognito`        | Local or deployed testing with real auth | Provide every Cognito variable. This overrides demo auth.                               |
+| `pages-demo`     | GitHub Pages public demo                 | Use `/template-vite-react/`, keep Cognito blank, and set `VITE_DEMO_AUTH_ENABLED=true`. |
 
 Important variables:
 
 - `VITE_PUBLIC_BASE_PATH`: router and asset base path. Use `/` for local dev.
 - `VITE_CF_DOMAIN`: public app origin used by auth redirects.
+- `VITE_DEMO_AUTH_ENABLED`: set to `true` only for demo auth. Demo auth works
+  only when all Cognito values are blank.
 - `VITE_IDP_ENABLED`: set to `true` only when the external identity provider
   button should be shown.
 - `VITE_AWS_REGION`, `VITE_COGNITO_DOMAIN`, `VITE_USER_POOL_ID`,
   `VITE_USER_POOL_CLIENT_ID`, `VITE_COGNITO_REDIRECT_SIGN_IN`, and
   `VITE_COGNITO_REDIRECT_SIGN_OUT`: Cognito configuration for Amplify auth.
 
-Leave Cognito values blank or unset when auth should be disabled. Missing or
-invalid Cognito settings are treated as auth disabled so the public demo does not
-expose a real user pool.
+Leave Cognito values blank or unset when auth should be disabled or demo auth
+should be used. Partial Cognito settings are treated as `unknown` profile
+configuration and keep auth disabled until the values are completed or removed.
 
 ## Local Development
 
@@ -169,13 +180,15 @@ The Pages build uses these public environment values:
 ```shell
 VITE_PUBLIC_BASE_PATH=/template-vite-react/
 VITE_CF_DOMAIN=https://aquia-inc.github.io/template-vite-react/
+VITE_DEMO_AUTH_ENABLED=true
 VITE_IDP_ENABLED=false
 ```
 
-Leave the Cognito environment values blank or unset for the public demo. For
-project Pages, Vite builds assets under `/template-vite-react/` and React Router
-uses the matching basename. The workflow also copies `dist/index.html` to
-`dist/404.html` so direct visits to client-side routes can load the SPA fallback.
+Leave the Cognito environment values blank or unset for the public demo. That
+selects the `pages-demo` profile. For project Pages, Vite builds assets under
+`/template-vite-react/` and React Router uses the matching basename. The workflow
+also copies `dist/index.html` to `dist/404.html` so direct visits to client-side
+routes can load the SPA fallback.
 
 ## Dependency And Security Triage
 

--- a/README.md
+++ b/README.md
@@ -46,20 +46,35 @@ corepack enable
 yarn install --immutable
 ```
 
-4. Install or refresh local hooks:
+4. Create the local development env file and install local hooks:
 
 ```shell
-yarn prepare
+yarn setup
 ```
 
-5. Create the local development env file:
+`yarn setup` verifies Node 24 and Yarn 4.14.1, copies `.env.example` to
+`.env.development.local` only when that file is missing, and runs
+`yarn prepare` for Husky hooks. Existing local env files are left unchanged.
+
+The legacy wrapper remains available when a shell script entrypoint is needed:
 
 ```shell
 sh ./scripts/post-install.sh
 ```
 
-The post-install script copies `.env.example` to `.env.development.local`.
-Update the copied file for real Cognito values only when testing auth locally.
+Update the copied env file for real Cognito values only when testing auth
+locally.
+
+5. Check the local setup:
+
+```shell
+yarn doctor
+```
+
+`yarn doctor` reports the detected Node version, Yarn version, local env-file
+presence, and auth profile. Wrong Node or Yarn versions fail the check. A missing
+`.env.development.local` is reported as a warning so first-time setup remains
+clear.
 
 ## Environment And Auth
 
@@ -106,6 +121,7 @@ yarn sb
 Run the same categories of checks used by CI:
 
 ```shell
+yarn doctor
 yarn lint
 yarn test
 yarn build

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ sh ./scripts/post-install.sh
 The post-install script copies `.env.example` to `.env.development.local`.
 Update the copied file for real Cognito values only when testing auth locally.
 
+## Template Rebranding
+
+After copying this template, preview the identity changes before writing them:
+
+```shell
+yarn init:template --app-name "Example Portal" --package-name example-portal --github-org example-org --repo-name example-portal --org-name "Example Org" --org-url https://example.com/
+```
+
+Add `--write` to update package metadata, README URLs, Pages defaults, app-visible
+names, Storybook intro text, and the demo auth storage key. The command is
+deterministic and only replaces known template identity values.
+
 ## Environment And Auth
 
 The app reads public Vite environment variables from `.env*` files. Local

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "scripts": {
     "start": "yarn run dev",
+    "setup": "node ./scripts/setup.mjs",
+    "doctor": "node ./scripts/doctor.mjs",
     "dev": "vite",
     "dev:e2e": "vite --mode test --host 127.0.0.1 --port 4173 --strictPort",
     "build": "tsc -p tsconfig.prod.json && vite build --mode production",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "tsc -p tsconfig.prod.json && vite build --mode production",
     "preview": "vite preview",
     "clean": "rimraf dist",
+    "init:template": "node scripts/init-template.mjs",
     "test": "NODE_ENV=test jest --coverage --colors --maxWorkers=50%",
     "test:precommit": "NODE_ENV=test jest --onlyChanged --coverage --colors --watch=false --maxWorkers=50%",
     "test:watch": "NODE_ENV=test jest --onlyChanged --coverage --colors --watch --maxWorkers=25%",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import process from 'node:process'
+
+import {
+  checkRuntime,
+  detectAuthProfile,
+  ENV_LOCAL_FILE,
+  printRuntimeErrors,
+  readLocalEnv,
+  REQUIRED_NODE_MAJOR,
+  REQUIRED_YARN_VERSION,
+  writer,
+} from './setup-doctor-core.mjs'
+
+export { detectAuthProfile } from './setup-doctor-core.mjs'
+
+export const runDoctor = async ({
+  cwd = process.cwd(),
+  env = process.env,
+  nodeVersion = process.versions.node,
+  stdout = writer(process.stdout),
+  stderr = writer(process.stderr),
+  runCommand,
+} = {}) => {
+  const runtime = checkRuntime({ cwd, env, nodeVersion, runCommand })
+  const localEnv = await readLocalEnv(cwd)
+  const envPresent = localEnv !== null
+  const authProfile = envPresent ? detectAuthProfile(localEnv) : 'unavailable'
+
+  stdout.write(
+    `Node: ${runtime.nodeVersion} (${
+      runtime.nodeOk ? 'ok' : `expected ${REQUIRED_NODE_MAJOR}`
+    })`,
+  )
+  stdout.write(
+    `Yarn: ${runtime.yarnVersion ?? 'not found'} (${
+      runtime.yarnOk ? 'ok' : `expected ${REQUIRED_YARN_VERSION}`
+    })`,
+  )
+  stdout.write(
+    `env file: ${envPresent ? `present (${ENV_LOCAL_FILE})` : 'missing (warning)'}`,
+  )
+  stdout.write(`auth profile: ${authProfile}`)
+
+  if (!runtime.ok) {
+    printRuntimeErrors(runtime, stderr)
+  }
+
+  if (!envPresent) {
+    stderr.write(
+      `Warning: ${ENV_LOCAL_FILE} is missing. Run \`yarn setup\` to create it from .env.example.`,
+    )
+  }
+
+  return runtime.ok ? 0 : 1
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await runDoctor()
+}

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 import {
   checkRuntime,
   detectAuthProfile,
-  ENV_LOCAL_FILE,
   printRuntimeErrors,
-  readLocalEnv,
+  readViteEnv,
   REQUIRED_NODE_MAJOR,
   REQUIRED_YARN_VERSION,
   writer,
@@ -23,9 +23,13 @@ export const runDoctor = async ({
   runCommand,
 } = {}) => {
   const runtime = checkRuntime({ cwd, env, nodeVersion, runCommand })
-  const localEnv = await readLocalEnv(cwd)
-  const envPresent = localEnv !== null
-  const authProfile = envPresent ? detectAuthProfile(localEnv) : 'unavailable'
+  const viteEnv = await readViteEnv({ cwd, env })
+  const envPresent = viteEnv.envFiles.length > 0 || viteEnv.hasProcessEnv
+  const envSources = [
+    ...viteEnv.envFiles,
+    ...(viteEnv.hasProcessEnv ? ['process env'] : []),
+  ]
+  const authProfile = detectAuthProfile(viteEnv.values)
 
   stdout.write(
     `Node: ${runtime.nodeVersion} (${
@@ -38,7 +42,7 @@ export const runDoctor = async ({
     })`,
   )
   stdout.write(
-    `env file: ${envPresent ? `present (${ENV_LOCAL_FILE})` : 'missing (warning)'}`,
+    `env sources: ${envPresent ? envSources.join(', ') : 'missing (warning)'}`,
   )
   stdout.write(`auth profile: ${authProfile}`)
 
@@ -48,13 +52,16 @@ export const runDoctor = async ({
 
   if (!envPresent) {
     stderr.write(
-      `Warning: ${ENV_LOCAL_FILE} is missing. Run \`yarn setup\` to create it from .env.example.`,
+      'Warning: no Vite env sources found. Run `yarn setup` to create .env.development.local from .env.example.',
     )
   }
 
   return runtime.ok ? 0 : 1
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   process.exitCode = await runDoctor()
 }

--- a/scripts/init-template.mjs
+++ b/scripts/init-template.mjs
@@ -270,14 +270,14 @@ const getTextReplacementSpecs = (target) => [
     path: '.github/workflows/cicd.yaml',
     replacements: [
       {
-        label: 'workflow Pages base path',
-        search: CURRENT.pagesBasePath,
-        replacement: target.pagesBasePath,
-      },
-      {
         label: 'workflow Pages URL',
         search: CURRENT.pagesUrl,
         replacement: target.pagesUrl,
+      },
+      {
+        label: 'workflow Pages base path',
+        search: CURRENT.pagesBasePath,
+        replacement: target.pagesBasePath,
       },
     ],
   },

--- a/scripts/init-template.mjs
+++ b/scripts/init-template.mjs
@@ -1,0 +1,457 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const CURRENT = {
+  appName: 'template-vite-react',
+  description: 'Boilerplate for React + Vite project',
+  githubOrg: 'aquia-inc',
+  githubUrl: 'https://github.com/aquia-inc/template-vite-react',
+  orgName: 'Aquia',
+  orgUrl: 'https://aquia.us/',
+  packageAuthor: 'Aquia, Inc.',
+  packageName: 'template-vite-react',
+  pagesBasePath: '/template-vite-react/',
+  pagesUrl: 'https://aquia-inc.github.io/template-vite-react/',
+  publicAppName: 'Vite-React App',
+  storybookTitle: 'Template/Introduction',
+  storageKey: 'template-vite-react:demo-auth-session',
+}
+
+const REQUIRED_FLAGS = ['appName', 'githubOrg', 'repoName', 'orgName', 'orgUrl']
+
+const FLAG_NAMES = new Map([
+  ['--app-name', 'appName'],
+  ['--package-name', 'packageName'],
+  ['--github-org', 'githubOrg'],
+  ['--repo-name', 'repoName'],
+  ['--org-name', 'orgName'],
+  ['--org-url', 'orgUrl'],
+])
+
+const usage = `Usage:
+  yarn init:template --app-name "Example Portal" --package-name example-portal --github-org example-org --repo-name example-portal --org-name "Example Org" --org-url https://example.com/ [--write]
+
+Required flags:
+  --app-name      Human-visible application name
+  --github-org    GitHub organization or user that owns the repository
+  --repo-name     GitHub repository name
+  --org-name      Human-visible organization name
+  --org-url       Organization website URL
+
+Optional flags:
+  --package-name  package.json name; defaults to --repo-name
+  --write         Apply replacements. Omit for dry-run mode.
+  --help          Show this help text.
+`
+
+const toCamelFlag = (name) =>
+  `--${name.replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)}`
+
+const normalizePagesBasePath = (repoName) =>
+  `/${repoName.replace(/^\/+|\/+$/g, '')}/`
+
+const replaceAll = (value, search, replacement) => {
+  const count = value.split(search).length - 1
+
+  return {
+    count,
+    value: value.replaceAll(search, replacement),
+  }
+}
+
+const applyTextReplacements = (content, replacements) => {
+  let nextContent = content
+  const applied = []
+
+  for (const replacement of replacements) {
+    const result = replaceAll(
+      nextContent,
+      replacement.search,
+      replacement.replacement,
+    )
+
+    nextContent = result.value
+
+    if (result.count > 0) {
+      applied.push({
+        label: replacement.label,
+        count: result.count,
+      })
+    }
+  }
+
+  return {
+    applied,
+    content: nextContent,
+  }
+}
+
+const parseArgs = (argv) => {
+  const options = {
+    write: false,
+  }
+  const errors = []
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (arg === '--help') {
+      options.help = true
+      continue
+    }
+
+    if (arg === '--write') {
+      options.write = true
+      continue
+    }
+
+    const optionName = FLAG_NAMES.get(arg)
+
+    if (!optionName) {
+      errors.push(`Unknown flag: ${arg}`)
+      continue
+    }
+
+    const value = argv[index + 1]
+
+    if (!value || value.startsWith('--')) {
+      errors.push(`Missing value for ${arg}`)
+      continue
+    }
+
+    options[optionName] = value
+    index += 1
+  }
+
+  return {
+    errors,
+    options,
+  }
+}
+
+export const buildTargetIdentity = (options) => {
+  const packageName = options.packageName ?? options.repoName
+  const pagesBasePath = normalizePagesBasePath(options.repoName)
+  const githubUrl = `https://github.com/${options.githubOrg}/${options.repoName}`
+
+  return {
+    appName: options.appName,
+    packageName,
+    githubOrg: options.githubOrg,
+    repoName: options.repoName,
+    orgName: options.orgName,
+    orgUrl: options.orgUrl,
+    githubUrl,
+    pagesBasePath,
+    pagesUrl: `https://${options.githubOrg}.github.io/${options.repoName}/`,
+    demoAuthStorageKey: `${packageName}:demo-auth-session`,
+  }
+}
+
+const getTextReplacementSpecs = (target) => [
+  {
+    path: 'README.md',
+    replacements: [
+      {
+        label: 'README title',
+        search: `# ${CURRENT.appName}`,
+        replacement: `# ${target.appName}`,
+      },
+      {
+        label: 'README clone URL',
+        search: `git clone git@github.com:${CURRENT.githubOrg}/${CURRENT.appName}.git`,
+        replacement: `git clone git@github.com:${target.githubOrg}/${target.repoName}.git`,
+      },
+      {
+        label: 'README checkout directory',
+        search: `cd ${CURRENT.appName}`,
+        replacement: `cd ${target.repoName}`,
+      },
+      {
+        label: 'README Pages URL',
+        search: CURRENT.pagesUrl,
+        replacement: target.pagesUrl,
+      },
+      {
+        label: 'README Pages base path',
+        search: `VITE_PUBLIC_BASE_PATH=${CURRENT.pagesBasePath}`,
+        replacement: `VITE_PUBLIC_BASE_PATH=${target.pagesBasePath}`,
+      },
+      {
+        label: 'README Pages domain',
+        search: `VITE_CF_DOMAIN=${CURRENT.pagesUrl}`,
+        replacement: `VITE_CF_DOMAIN=${target.pagesUrl}`,
+      },
+      {
+        label: 'README asset base path',
+        search: `\`${CURRENT.pagesBasePath}\``,
+        replacement: `\`${target.pagesBasePath}\``,
+      },
+    ],
+  },
+  {
+    path: 'src/constants.ts',
+    replacements: [
+      {
+        label: 'organization name constant',
+        search: `export const ORG_NAME = '${CURRENT.orgName}'`,
+        replacement: `export const ORG_NAME = '${target.orgName}'`,
+      },
+      {
+        label: 'organization URL constant',
+        search: `export const ORG_URL = '${CURRENT.orgUrl}'`,
+        replacement: `export const ORG_URL = '${target.orgUrl}'`,
+      },
+      {
+        label: 'template GitHub URL constant',
+        search: CURRENT.githubUrl,
+        replacement: target.githubUrl,
+      },
+    ],
+  },
+  {
+    path: 'src/utils/demoAuth.ts',
+    replacements: [
+      {
+        label: 'demo auth storage key',
+        search: CURRENT.storageKey,
+        replacement: target.demoAuthStorageKey,
+      },
+    ],
+  },
+  {
+    path: 'src/utils/demoAuth.test.ts',
+    replacements: [
+      {
+        label: 'demo auth test storage key',
+        search: CURRENT.storageKey,
+        replacement: target.demoAuthStorageKey,
+      },
+    ],
+  },
+  {
+    path: 'src/locales/en.ts',
+    replacements: [
+      {
+        label: 'public app name',
+        search: `export const PUBLIC_APP_NAME = '${CURRENT.publicAppName}'`,
+        replacement: `export const PUBLIC_APP_NAME = '${target.appName}'`,
+      },
+    ],
+  },
+  {
+    path: 'src/views/Home/Home.tsx',
+    replacements: [
+      {
+        label: 'home visible template name',
+        search: CURRENT.appName,
+        replacement: target.appName,
+      },
+    ],
+  },
+  {
+    path: 'src/stories/Introduction.mdx',
+    replacements: [
+      {
+        label: 'Storybook introduction title',
+        search: CURRENT.storybookTitle,
+        replacement: `${target.appName}/Introduction`,
+      },
+      {
+        label: 'Storybook introduction heading',
+        search: `# ${CURRENT.appName}`,
+        replacement: `# ${target.appName}`,
+      },
+    ],
+  },
+  {
+    path: '.github/workflows/cicd.yaml',
+    replacements: [
+      {
+        label: 'workflow Pages base path',
+        search: CURRENT.pagesBasePath,
+        replacement: target.pagesBasePath,
+      },
+      {
+        label: 'workflow Pages URL',
+        search: CURRENT.pagesUrl,
+        replacement: target.pagesUrl,
+      },
+    ],
+  },
+  {
+    path: 'playwright.config.ts',
+    replacements: [
+      {
+        label: 'Playwright Pages default base path',
+        search: CURRENT.pagesBasePath,
+        replacement: target.pagesBasePath,
+      },
+    ],
+  },
+  {
+    path: 'src/utils/publicBasePath.test.ts',
+    replacements: [
+      {
+        label: 'public base path test values',
+        search: CURRENT.appName,
+        replacement: target.repoName,
+      },
+    ],
+  },
+]
+
+const updatePackageJson = (content, target) => {
+  const packageJson = JSON.parse(content)
+  const applied = []
+  const setIfCurrent = (key, currentValue, nextValue) => {
+    if (packageJson[key] === currentValue) {
+      packageJson[key] = nextValue
+      applied.push({ label: `package ${key}`, count: 1 })
+    }
+  }
+
+  setIfCurrent('name', CURRENT.packageName, target.packageName)
+  setIfCurrent(
+    'description',
+    CURRENT.description,
+    `${target.appName} React application`,
+  )
+  setIfCurrent(
+    'homepage',
+    `${CURRENT.githubUrl}#readme`,
+    `${target.githubUrl}#readme`,
+  )
+  setIfCurrent('author', CURRENT.packageAuthor, target.orgName)
+
+  if (packageJson.bugs?.url === `${CURRENT.githubUrl}/issues`) {
+    packageJson.bugs.url = `${target.githubUrl}/issues`
+    applied.push({ label: 'package bugs URL', count: 1 })
+  }
+
+  return {
+    applied,
+    content: `${JSON.stringify(packageJson, null, 2)}\n`,
+  }
+}
+
+const createPlanEntry = async (root, spec, target) => {
+  const filePath = join(root, spec.path)
+
+  if (!existsSync(filePath)) {
+    return {
+      applied: [],
+      missing: true,
+      path: spec.path,
+    }
+  }
+
+  const content = await readFile(filePath, 'utf8')
+  const result =
+    spec.path === 'package.json'
+      ? updatePackageJson(content, target)
+      : applyTextReplacements(content, spec.replacements)
+
+  return {
+    applied: result.applied,
+    content: result.content,
+    changed: result.content !== content,
+    path: spec.path,
+  }
+}
+
+export const createReplacementPlan = async (root, target) => {
+  const specs = [
+    {
+      path: 'package.json',
+    },
+    ...getTextReplacementSpecs(target),
+  ]
+  const entries = []
+
+  for (const spec of specs) {
+    entries.push(await createPlanEntry(root, spec, target))
+  }
+
+  return entries
+}
+
+const formatPlan = (plan, write) => {
+  const changedEntries = plan.filter((entry) => entry.changed)
+  const skippedEntries = plan.filter((entry) => entry.missing)
+  const lines = [
+    write
+      ? 'WRITE MODE: applying template identity replacements.'
+      : 'DRY RUN: no files changed.',
+  ]
+
+  if (changedEntries.length === 0) {
+    lines.push('- No matching template identity values found.')
+  }
+
+  for (const entry of changedEntries) {
+    const count = entry.applied.reduce((total, item) => total + item.count, 0)
+    lines.push(`- ${entry.path}: ${count} replacement(s)`)
+  }
+
+  for (const entry of skippedEntries) {
+    lines.push(`- ${entry.path}: skipped; file not present`)
+  }
+
+  return lines.join('\n')
+}
+
+const validateRequiredFlags = (options) =>
+  REQUIRED_FLAGS.filter((flagName) => !options[flagName])
+
+export const runInitTemplate = async (
+  argv,
+  {
+    cwd = process.cwd(),
+    stdout = (message) => console.log(message),
+    stderr = (message) => console.error(message),
+  } = {},
+) => {
+  const { errors, options } = parseArgs(argv)
+
+  if (options.help) {
+    stdout(usage)
+    return { exitCode: 0 }
+  }
+
+  const missingFlags = validateRequiredFlags(options)
+
+  if (errors.length > 0 || missingFlags.length > 0) {
+    const messages = [...errors]
+
+    if (missingFlags.length > 0) {
+      messages.push(
+        `Missing required flags: ${missingFlags.map(toCamelFlag).join(', ')}`,
+      )
+    }
+
+    stderr(`${messages.join('\n')}\n\n${usage}`)
+    return { exitCode: 1 }
+  }
+
+  const target = buildTargetIdentity(options)
+  const plan = await createReplacementPlan(cwd, target)
+
+  if (options.write) {
+    for (const entry of plan) {
+      if (entry.changed) {
+        await writeFile(join(cwd, entry.path), entry.content)
+      }
+    }
+  }
+
+  stdout(formatPlan(plan, options.write))
+  return { exitCode: 0, plan, target }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await runInitTemplate(process.argv.slice(2))
+  process.exitCode = result.exitCode
+}

--- a/scripts/init-template.test.mjs
+++ b/scripts/init-template.test.mjs
@@ -227,6 +227,10 @@ test('write mode updates deterministic template identity values', async () => {
     /\/example-portal\//,
   )
   assert.match(
+    await readFile(join(root, '.github/workflows/cicd.yaml'), 'utf8'),
+    /https:\/\/example-org\.github\.io\/example-portal\//,
+  )
+  assert.match(
     await readFile(join(root, 'playwright.config.ts'), 'utf8'),
     /\/example-portal\//,
   )

--- a/scripts/init-template.test.mjs
+++ b/scripts/init-template.test.mjs
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import test from 'node:test'
+
+import { buildTargetIdentity, runInitTemplate } from './init-template.mjs'
+
+const sampleArgs = [
+  '--app-name',
+  'Example Portal',
+  '--package-name',
+  'example-portal',
+  '--github-org',
+  'example-org',
+  '--repo-name',
+  'example-portal',
+  '--org-name',
+  'Example Org',
+  '--org-url',
+  'https://example.com/',
+]
+
+const writeFixture = async () => {
+  const root = await mkdtemp(join(tmpdir(), 'init-template-'))
+
+  await mkdir(join(root, 'src/utils'), { recursive: true })
+  await mkdir(join(root, 'src/views/Home'), { recursive: true })
+  await mkdir(join(root, 'src/stories'), { recursive: true })
+  await mkdir(join(root, 'src/locales'), { recursive: true })
+  await mkdir(join(root, '.github/workflows'), { recursive: true })
+
+  await writeFile(
+    join(root, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'template-vite-react',
+        description: 'Boilerplate for React + Vite project',
+        homepage: 'https://github.com/aquia-inc/template-vite-react#readme',
+        bugs: {
+          url: 'https://github.com/aquia-inc/template-vite-react/issues',
+        },
+        author: 'Aquia, Inc.',
+        scripts: {},
+      },
+      null,
+      2,
+    ),
+  )
+  await writeFile(
+    join(root, 'README.md'),
+    [
+      '# template-vite-react',
+      'git clone git@github.com:aquia-inc/template-vite-react.git',
+      'cd template-vite-react',
+      'https://aquia-inc.github.io/template-vite-react/',
+      'VITE_PUBLIC_BASE_PATH=/template-vite-react/',
+      'VITE_CF_DOMAIN=https://aquia-inc.github.io/template-vite-react/',
+      'assets under `/template-vite-react/`',
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    join(root, 'src/constants.ts'),
+    [
+      "export const ORG_NAME = 'Aquia'",
+      "export const ORG_URL = 'https://aquia.us/'",
+      'export const TEMPLATE_GITHUB_URL =',
+      "  'https://github.com/aquia-inc/template-vite-react'",
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    join(root, 'src/utils/demoAuth.ts'),
+    "const DEMO_AUTH_STORAGE_KEY = 'template-vite-react:demo-auth-session'\n",
+  )
+  await writeFile(
+    join(root, 'src/utils/demoAuth.test.ts'),
+    "window.sessionStorage.getItem('template-vite-react:demo-auth-session')\n",
+  )
+  await writeFile(
+    join(root, 'src/locales/en.ts'),
+    "export const PUBLIC_APP_NAME = 'Vite-React App'\n",
+  )
+  await writeFile(
+    join(root, 'src/views/Home/Home.tsx'),
+    '<Typography>template-vite-react</Typography>\n',
+  )
+  await writeFile(
+    join(root, 'src/stories/Introduction.mdx'),
+    '<Meta title="Template/Introduction" />\n\n# template-vite-react\n',
+  )
+  await writeFile(
+    join(root, '.github/workflows/cicd.yaml'),
+    [
+      "VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}",
+      "VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}",
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    join(root, 'playwright.config.ts'),
+    "const normalizePagesBasePath = (value = '/template-vite-react/') => value\n",
+  )
+
+  return root
+}
+
+test('builds derived target identity from required flags', () => {
+  assert.deepEqual(
+    buildTargetIdentity({
+      appName: 'Example Portal',
+      packageName: 'example-portal',
+      githubOrg: 'example-org',
+      repoName: 'example-portal',
+      orgName: 'Example Org',
+      orgUrl: 'https://example.com/',
+    }),
+    {
+      appName: 'Example Portal',
+      packageName: 'example-portal',
+      githubOrg: 'example-org',
+      repoName: 'example-portal',
+      orgName: 'Example Org',
+      orgUrl: 'https://example.com/',
+      githubUrl: 'https://github.com/example-org/example-portal',
+      pagesBasePath: '/example-portal/',
+      pagesUrl: 'https://example-org.github.io/example-portal/',
+      demoAuthStorageKey: 'example-portal:demo-auth-session',
+    },
+  )
+})
+
+test('falls back to repo name for package name and demo auth storage key', () => {
+  const identity = buildTargetIdentity({
+    appName: 'Example Portal',
+    githubOrg: 'example-org',
+    repoName: 'example-portal',
+    orgName: 'Example Org',
+    orgUrl: 'https://example.com/',
+  })
+
+  assert.equal(identity.packageName, 'example-portal')
+  assert.equal(identity.demoAuthStorageKey, 'example-portal:demo-auth-session')
+})
+
+test('refuses missing required flags with a clear message', async () => {
+  const stderr = []
+  const result = await runInitTemplate(['--app-name', 'Example Portal'], {
+    cwd: await writeFixture(),
+    stderr: (message) => stderr.push(message),
+  })
+
+  assert.equal(result.exitCode, 1)
+  assert.match(stderr.join('\n'), /Missing required flags/)
+  assert.match(stderr.join('\n'), /--github-org/)
+})
+
+test('prints help without requiring flags', async () => {
+  const stdout = []
+  const result = await runInitTemplate(['--help'], {
+    cwd: await writeFixture(),
+    stdout: (message) => stdout.push(message),
+  })
+
+  assert.equal(result.exitCode, 0)
+  assert.match(stdout.join('\n'), /yarn init:template/)
+  assert.match(stdout.join('\n'), /--app-name/)
+})
+
+test('dry run reports planned replacements without modifying files', async () => {
+  const root = await writeFixture()
+  const packagePath = join(root, 'package.json')
+  const originalPackage = await readFile(packagePath, 'utf8')
+  const stdout = []
+
+  const result = await runInitTemplate(sampleArgs, {
+    cwd: root,
+    stdout: (message) => stdout.push(message),
+  })
+
+  assert.equal(result.exitCode, 0)
+  assert.equal(await readFile(packagePath, 'utf8'), originalPackage)
+  assert.match(stdout.join('\n'), /DRY RUN/)
+  assert.match(stdout.join('\n'), /package.json/)
+  assert.match(stdout.join('\n'), /src\/utils\/demoAuth.ts/)
+})
+
+test('write mode updates deterministic template identity values', async () => {
+  const root = await writeFixture()
+
+  const result = await runInitTemplate([...sampleArgs, '--write'], {
+    cwd: root,
+  })
+
+  assert.equal(result.exitCode, 0)
+  assert.match(
+    await readFile(join(root, 'package.json'), 'utf8'),
+    /"name": "example-portal"/,
+  )
+  assert.match(
+    await readFile(join(root, 'README.md'), 'utf8'),
+    /# Example Portal/,
+  )
+  assert.match(
+    await readFile(join(root, 'src/constants.ts'), 'utf8'),
+    /https:\/\/github\.com\/example-org\/example-portal/,
+  )
+  assert.match(
+    await readFile(join(root, 'src/utils/demoAuth.ts'), 'utf8'),
+    /example-portal:demo-auth-session/,
+  )
+  assert.match(
+    await readFile(join(root, 'src/locales/en.ts'), 'utf8'),
+    /Example Portal/,
+  )
+  assert.match(
+    await readFile(join(root, 'src/views/Home/Home.tsx'), 'utf8'),
+    /Example Portal/,
+  )
+  assert.match(
+    await readFile(join(root, 'src/stories/Introduction.mdx'), 'utf8'),
+    /Example Portal\/Introduction/,
+  )
+  assert.match(
+    await readFile(join(root, '.github/workflows/cicd.yaml'), 'utf8'),
+    /\/example-portal\//,
+  )
+  assert.match(
+    await readFile(join(root, 'playwright.config.ts'), 'utf8'),
+    /\/example-portal\//,
+  )
+})

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
-# FILEPATH: /Users/sinanbolel/code/@aquia/template-vite-react/scripts/post-install.sh
+#!/bin/sh
 
-cp .env.example .env.development.local
+node ./scripts/setup.mjs

--- a/scripts/setup-doctor-core.mjs
+++ b/scripts/setup-doctor-core.mjs
@@ -6,6 +6,12 @@ export const REQUIRED_NODE_MAJOR = 24
 export const REQUIRED_YARN_VERSION = '4.14.1'
 export const ENV_EXAMPLE_FILE = '.env.example'
 export const ENV_LOCAL_FILE = '.env.development.local'
+export const VITE_ENV_FILES = [
+  '.env',
+  '.env.local',
+  '.env.development',
+  ENV_LOCAL_FILE,
+]
 
 export const commandRunner = (command, args, options = {}) =>
   spawnSync(command, args, {
@@ -101,8 +107,15 @@ export const parseEnvFile = (content) => {
       continue
     }
 
-    const key = line.slice(0, delimiterIndex).trim()
+    const key = line
+      .slice(0, delimiterIndex)
+      .trim()
+      .replace(/^export\s+/, '')
     let value = line.slice(delimiterIndex + 1).trim()
+
+    if (!key) {
+      continue
+    }
 
     if (
       (value.startsWith("'") && value.endsWith("'")) ||
@@ -116,6 +129,13 @@ export const parseEnvFile = (content) => {
 
   return values
 }
+
+const getProcessViteEnv = (env = {}) =>
+  Object.fromEntries(
+    Object.entries(env).filter(
+      ([key, value]) => key.startsWith('VITE_') && value !== undefined,
+    ),
+  )
 
 const isUrl = (value = '') => {
   try {
@@ -186,6 +206,33 @@ export const readLocalEnv = async (cwd) => {
   }
 
   return parseEnvFile(await readFile(envPath, 'utf8'))
+}
+
+export const readViteEnv = async ({ cwd, env = process.env } = {}) => {
+  const values = {}
+  const envFiles = []
+
+  for (const envFile of VITE_ENV_FILES) {
+    const envPath = path.join(cwd, envFile)
+
+    if (!(await fileExists(envPath))) {
+      continue
+    }
+
+    Object.assign(values, parseEnvFile(await readFile(envPath, 'utf8')))
+    envFiles.push(envFile)
+  }
+
+  const processEnv = getProcessViteEnv(env)
+
+  return {
+    envFiles,
+    hasProcessEnv: Object.keys(processEnv).length > 0,
+    values: {
+      ...values,
+      ...processEnv,
+    },
+  }
 }
 
 export const ensureLocalEnv = async (cwd) => {

--- a/scripts/setup-doctor-core.mjs
+++ b/scripts/setup-doctor-core.mjs
@@ -131,6 +131,14 @@ const hasValue = (value = '') => value.trim().length > 0
 const isValidUserPoolId = (value = '') =>
   /^[a-z0-9-]+_[A-Za-z0-9]+$/.test(value)
 
+const getCognitoSpecificValues = (authConfig) => [
+  authConfig.COGNITO_DOMAIN,
+  authConfig.COGNITO_REDIRECT_SIGN_IN,
+  authConfig.COGNITO_REDIRECT_SIGN_OUT,
+  authConfig.USER_POOL_CLIENT_ID,
+  authConfig.USER_POOL_ID,
+]
+
 export const detectAuthProfile = (env) => {
   const authConfig = {
     AWS_REGION: env.VITE_AWS_REGION ?? '',
@@ -140,9 +148,11 @@ export const detectAuthProfile = (env) => {
     USER_POOL_CLIENT_ID: env.VITE_USER_POOL_CLIENT_ID ?? '',
     USER_POOL_ID: env.VITE_USER_POOL_ID ?? '',
   }
-  const values = Object.values(authConfig)
-  const allBlank = values.every((value) => value.trim() === '')
-  const anyPresent = values.some(hasValue)
+  const cognitoSpecificValues = getCognitoSpecificValues(authConfig)
+  const cognitoSpecificValuesBlank = cognitoSpecificValues.every(
+    (value) => value.trim() === '',
+  )
+  const anyCognitoSpecificValuePresent = cognitoSpecificValues.some(hasValue)
   const cognitoValid =
     hasValue(authConfig.AWS_REGION) &&
     isValidUserPoolId(authConfig.USER_POOL_ID) &&
@@ -155,13 +165,13 @@ export const detectAuthProfile = (env) => {
     return 'cognito'
   }
 
-  if (allBlank && env.VITE_DEMO_AUTH_ENABLED === 'true') {
+  if (cognitoSpecificValuesBlank && env.VITE_DEMO_AUTH_ENABLED === 'true') {
     return env.VITE_PUBLIC_BASE_PATH && env.VITE_PUBLIC_BASE_PATH !== '/'
       ? 'pages-demo'
       : 'local-demo'
   }
 
-  if (anyPresent) {
+  if (anyCognitoSpecificValuePresent) {
     return 'unknown'
   }
 

--- a/scripts/setup-doctor-core.mjs
+++ b/scripts/setup-doctor-core.mjs
@@ -1,0 +1,195 @@
+import { spawnSync } from 'node:child_process'
+import { access, copyFile, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export const REQUIRED_NODE_MAJOR = 24
+export const REQUIRED_YARN_VERSION = '4.14.1'
+export const ENV_EXAMPLE_FILE = '.env.example'
+export const ENV_LOCAL_FILE = '.env.development.local'
+
+export const commandRunner = (command, args, options = {}) =>
+  spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    shell: false,
+    stdio: options.stdio ?? 'pipe',
+  })
+
+export const writer = (stream) => ({
+  write: (message) => stream.write(`${message}\n`),
+})
+
+export const fileExists = async (filePath) => {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const parseYarnVersionFromUserAgent = (userAgent = '') => {
+  const match = userAgent.match(/(?:^|\s)yarn\/([^\s]+)/)
+  return match?.[1] ?? null
+}
+
+export const getYarnVersion = ({ cwd, env, runCommand = commandRunner }) => {
+  const userAgentVersion = parseYarnVersionFromUserAgent(
+    env.npm_config_user_agent,
+  )
+
+  if (userAgentVersion) {
+    return userAgentVersion
+  }
+
+  const result = runCommand('yarn', ['-v'], { cwd })
+
+  if (result.status === 0 && result.stdout) {
+    return result.stdout.trim()
+  }
+
+  return null
+}
+
+export const checkRuntime = ({
+  cwd,
+  env = process.env,
+  nodeVersion = process.versions.node,
+  runCommand = commandRunner,
+} = {}) => {
+  const nodeMajor = Number.parseInt(nodeVersion.split('.')[0] ?? '', 10)
+  const yarnVersion = getYarnVersion({ cwd, env, runCommand })
+  const errors = []
+
+  if (nodeMajor !== REQUIRED_NODE_MAJOR) {
+    errors.push(
+      `Node ${REQUIRED_NODE_MAJOR} is required; detected ${nodeVersion}.`,
+    )
+  }
+
+  if (yarnVersion !== REQUIRED_YARN_VERSION) {
+    errors.push(
+      `Yarn ${REQUIRED_YARN_VERSION} is required; detected ${
+        yarnVersion ?? 'not found'
+      }.`,
+    )
+  }
+
+  return {
+    errors,
+    nodeOk: nodeMajor === REQUIRED_NODE_MAJOR,
+    nodeVersion,
+    yarnOk: yarnVersion === REQUIRED_YARN_VERSION,
+    yarnVersion,
+    ok: errors.length === 0,
+  }
+}
+
+export const parseEnvFile = (content) => {
+  const values = {}
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+
+    const delimiterIndex = line.indexOf('=')
+
+    if (delimiterIndex === -1) {
+      continue
+    }
+
+    const key = line.slice(0, delimiterIndex).trim()
+    let value = line.slice(delimiterIndex + 1).trim()
+
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    values[key] = value
+  }
+
+  return values
+}
+
+const isUrl = (value = '') => {
+  try {
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const hasValue = (value = '') => value.trim().length > 0
+
+const isValidUserPoolId = (value = '') =>
+  /^[a-z0-9-]+_[A-Za-z0-9]+$/.test(value)
+
+export const detectAuthProfile = (env) => {
+  const authConfig = {
+    AWS_REGION: env.VITE_AWS_REGION ?? '',
+    COGNITO_DOMAIN: env.VITE_COGNITO_DOMAIN ?? '',
+    COGNITO_REDIRECT_SIGN_IN: env.VITE_COGNITO_REDIRECT_SIGN_IN ?? '',
+    COGNITO_REDIRECT_SIGN_OUT: env.VITE_COGNITO_REDIRECT_SIGN_OUT ?? '',
+    USER_POOL_CLIENT_ID: env.VITE_USER_POOL_CLIENT_ID ?? '',
+    USER_POOL_ID: env.VITE_USER_POOL_ID ?? '',
+  }
+  const values = Object.values(authConfig)
+  const allBlank = values.every((value) => value.trim() === '')
+  const anyPresent = values.some(hasValue)
+  const cognitoValid =
+    hasValue(authConfig.AWS_REGION) &&
+    isValidUserPoolId(authConfig.USER_POOL_ID) &&
+    hasValue(authConfig.USER_POOL_CLIENT_ID) &&
+    isUrl(authConfig.COGNITO_DOMAIN) &&
+    isUrl(authConfig.COGNITO_REDIRECT_SIGN_IN) &&
+    isUrl(authConfig.COGNITO_REDIRECT_SIGN_OUT)
+
+  if (cognitoValid) {
+    return 'cognito'
+  }
+
+  if (allBlank && env.VITE_DEMO_AUTH_ENABLED === 'true') {
+    return 'demo'
+  }
+
+  if (anyPresent) {
+    return 'invalid-cognito'
+  }
+
+  return 'disabled'
+}
+
+export const readLocalEnv = async (cwd) => {
+  const envPath = path.join(cwd, ENV_LOCAL_FILE)
+
+  if (!(await fileExists(envPath))) {
+    return null
+  }
+
+  return parseEnvFile(await readFile(envPath, 'utf8'))
+}
+
+export const ensureLocalEnv = async (cwd) => {
+  const sourcePath = path.join(cwd, ENV_EXAMPLE_FILE)
+  const targetPath = path.join(cwd, ENV_LOCAL_FILE)
+
+  if (await fileExists(targetPath)) {
+    return 'existing'
+  }
+
+  await copyFile(sourcePath, targetPath)
+  return 'created'
+}
+
+export const printRuntimeErrors = (runtime, stderr) => {
+  for (const error of runtime.errors) {
+    stderr.write(`Error: ${error}`)
+  }
+}

--- a/scripts/setup-doctor-core.mjs
+++ b/scripts/setup-doctor-core.mjs
@@ -156,14 +156,16 @@ export const detectAuthProfile = (env) => {
   }
 
   if (allBlank && env.VITE_DEMO_AUTH_ENABLED === 'true') {
-    return 'demo'
+    return env.VITE_PUBLIC_BASE_PATH && env.VITE_PUBLIC_BASE_PATH !== '/'
+      ? 'pages-demo'
+      : 'local-demo'
   }
 
   if (anyPresent) {
-    return 'invalid-cognito'
+    return 'unknown'
   }
 
-  return 'disabled'
+  return 'local-disabled'
 }
 
 export const readLocalEnv = async (cwd) => {

--- a/scripts/setup-doctor.test.mjs
+++ b/scripts/setup-doctor.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { detectAuthProfile, runDoctor } from './doctor.mjs'
+import { runSetup } from './setup.mjs'
+
+const makeFixture = async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'template-vite-react-'))
+  await writeFile(
+    path.join(cwd, '.env.example'),
+    "VITE_DEMO_AUTH_ENABLED='false'\nVITE_IDP_ENABLED='false'\n",
+  )
+
+  return cwd
+}
+
+const makeRecorder = () => {
+  const messages = []
+
+  return {
+    messages,
+    write: (message) => messages.push(message),
+  }
+}
+
+test('runSetup creates the development env file when it is missing', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+  const commands = []
+
+  try {
+    const exitCode = await runSetup({
+      cwd,
+      env: {
+        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
+      },
+      nodeVersion: '24.15.0',
+      runCommand: (command, args) => {
+        commands.push([command, args])
+        return { status: 0 }
+      },
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.equal(
+      await readFile(path.join(cwd, '.env.development.local'), 'utf8'),
+      "VITE_DEMO_AUTH_ENABLED='false'\nVITE_IDP_ENABLED='false'\n",
+    )
+    assert.deepEqual(commands, [['yarn', ['prepare']]])
+    assert.match(out.messages.join('\n'), /created/i)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runSetup preserves an existing development env file', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+  await writeFile(path.join(cwd, '.env.development.local'), 'LOCAL_ONLY=true\n')
+
+  try {
+    const exitCode = await runSetup({
+      cwd,
+      env: {
+        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
+      },
+      nodeVersion: '24.15.0',
+      runCommand: () => ({ status: 0 }),
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.equal(
+      await readFile(path.join(cwd, '.env.development.local'), 'utf8'),
+      'LOCAL_ONLY=true\n',
+    )
+    assert.match(out.messages.join('\n'), /already exists/i)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runSetup fails on runtime version mismatches before preparing hooks', async () => {
+  const cwd = await makeFixture()
+  const commands = []
+
+  try {
+    const exitCode = await runSetup({
+      cwd,
+      env: {
+        npm_config_user_agent: 'yarn/4.13.0 npm/? node/v23.0.0 darwin arm64',
+      },
+      nodeVersion: '23.0.0',
+      runCommand: (command, args) => {
+        commands.push([command, args])
+        return { status: 0 }
+      },
+      stdout: makeRecorder(),
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 1)
+    assert.deepEqual(commands, [])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDoctor warns for a missing env file but succeeds with valid runtime', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+
+  try {
+    const exitCode = await runDoctor({
+      cwd,
+      env: {
+        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
+      },
+      nodeVersion: '24.15.0',
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.match(out.messages.join('\n'), /Node: 24\.15\.0/)
+    assert.match(out.messages.join('\n'), /Yarn: 4\.14\.1/)
+    assert.match(out.messages.join('\n'), /env file: missing/)
+    assert.match(out.messages.join('\n'), /auth profile: unavailable/)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDoctor fails for a wrong Yarn version', async () => {
+  const cwd = await makeFixture()
+
+  try {
+    const exitCode = await runDoctor({
+      cwd,
+      env: {
+        npm_config_user_agent: 'yarn/4.13.0 npm/? node/v24.15.0 darwin arm64',
+      },
+      nodeVersion: '24.15.0',
+      stdout: makeRecorder(),
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 1)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('detectAuthProfile distinguishes disabled, demo, and Cognito profiles', () => {
+  assert.equal(
+    detectAuthProfile({
+      VITE_DEMO_AUTH_ENABLED: 'false',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+    'disabled',
+  )
+  assert.equal(
+    detectAuthProfile({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+    'demo',
+  )
+  assert.equal(
+    detectAuthProfile({
+      VITE_DEMO_AUTH_ENABLED: 'false',
+      VITE_AWS_REGION: 'us-east-1',
+      VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
+      VITE_COGNITO_REDIRECT_SIGN_IN: 'http://localhost:3000/signin',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: 'http://localhost:3000/signout',
+      VITE_USER_POOL_CLIENT_ID: 'client-id',
+      VITE_USER_POOL_ID: 'us-east-1_abcd1234',
+    }),
+    'cognito',
+  )
+})

--- a/scripts/setup-doctor.test.mjs
+++ b/scripts/setup-doctor.test.mjs
@@ -26,6 +26,28 @@ const makeRecorder = () => {
   }
 }
 
+const validRuntimeEnv = {
+  npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
+}
+
+const blankCognitoEnv = {
+  VITE_AWS_REGION: 'us-east-1',
+  VITE_COGNITO_DOMAIN: '',
+  VITE_COGNITO_REDIRECT_SIGN_IN: '',
+  VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+  VITE_USER_POOL_CLIENT_ID: '',
+  VITE_USER_POOL_ID: '',
+}
+
+const validCognitoEnv = {
+  VITE_AWS_REGION: 'us-east-1',
+  VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
+  VITE_COGNITO_REDIRECT_SIGN_IN: 'http://localhost:3000/signin',
+  VITE_COGNITO_REDIRECT_SIGN_OUT: 'http://localhost:3000/signout',
+  VITE_USER_POOL_CLIENT_ID: 'client-id',
+  VITE_USER_POOL_ID: 'us-east-1_abcd1234',
+}
+
 test('runSetup creates the development env file when it is missing', async () => {
   const cwd = await makeFixture()
   const out = makeRecorder()
@@ -34,9 +56,7 @@ test('runSetup creates the development env file when it is missing', async () =>
   try {
     const exitCode = await runSetup({
       cwd,
-      env: {
-        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
-      },
+      env: validRuntimeEnv,
       nodeVersion: '24.15.0',
       runCommand: (command, args) => {
         commands.push([command, args])
@@ -66,9 +86,7 @@ test('runSetup preserves an existing development env file', async () => {
   try {
     const exitCode = await runSetup({
       cwd,
-      env: {
-        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
-      },
+      env: validRuntimeEnv,
       nodeVersion: '24.15.0',
       runCommand: () => ({ status: 0 }),
       stdout: out,
@@ -119,9 +137,7 @@ test('runDoctor warns for a missing env file but succeeds with valid runtime', a
   try {
     const exitCode = await runDoctor({
       cwd,
-      env: {
-        npm_config_user_agent: 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64',
-      },
+      env: validRuntimeEnv,
       nodeVersion: '24.15.0',
       stdout: out,
       stderr: makeRecorder(),
@@ -130,8 +146,105 @@ test('runDoctor warns for a missing env file but succeeds with valid runtime', a
     assert.equal(exitCode, 0)
     assert.match(out.messages.join('\n'), /Node: 24\.15\.0/)
     assert.match(out.messages.join('\n'), /Yarn: 4\.14\.1/)
-    assert.match(out.messages.join('\n'), /env file: missing/)
-    assert.match(out.messages.join('\n'), /auth profile: unavailable/)
+    assert.match(out.messages.join('\n'), /env sources: missing/)
+    assert.match(out.messages.join('\n'), /auth profile: local-disabled/)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDoctor merges Vite env files in development priority order', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+
+  await writeFile(path.join(cwd, '.env'), "VITE_DEMO_AUTH_ENABLED='false'\n")
+  await writeFile(
+    path.join(cwd, '.env.local'),
+    "VITE_DEMO_AUTH_ENABLED='true'\nVITE_PUBLIC_BASE_PATH='/template-vite-react/'\n",
+  )
+  await writeFile(
+    path.join(cwd, '.env.development'),
+    "VITE_PUBLIC_BASE_PATH='/'\n",
+  )
+  await writeFile(
+    path.join(cwd, '.env.development.local'),
+    "VITE_DEMO_AUTH_ENABLED='true'\n",
+  )
+
+  try {
+    const exitCode = await runDoctor({
+      cwd,
+      env: validRuntimeEnv,
+      nodeVersion: '24.15.0',
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.match(
+      out.messages.join('\n'),
+      /env sources: \.env, \.env\.local, \.env\.development, \.env\.development\.local/,
+    )
+    assert.match(out.messages.join('\n'), /auth profile: local-demo/)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDoctor lets .env.development alone affect auth profile detection', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+
+  await writeFile(
+    path.join(cwd, '.env.development'),
+    "VITE_DEMO_AUTH_ENABLED='true'\nVITE_PUBLIC_BASE_PATH='/template-vite-react/'\n",
+  )
+
+  try {
+    const exitCode = await runDoctor({
+      cwd,
+      env: validRuntimeEnv,
+      nodeVersion: '24.15.0',
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.match(out.messages.join('\n'), /env sources: \.env\.development/)
+    assert.match(out.messages.join('\n'), /auth profile: pages-demo/)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDoctor lets process env override Vite env files', async () => {
+  const cwd = await makeFixture()
+  const out = makeRecorder()
+
+  await writeFile(
+    path.join(cwd, '.env.development.local'),
+    "VITE_DEMO_AUTH_ENABLED='false'\nVITE_PUBLIC_BASE_PATH='/template-vite-react/'\n",
+  )
+
+  try {
+    const exitCode = await runDoctor({
+      cwd,
+      env: {
+        ...validRuntimeEnv,
+        VITE_DEMO_AUTH_ENABLED: 'true',
+        VITE_PUBLIC_BASE_PATH: '/',
+      },
+      nodeVersion: '24.15.0',
+      stdout: out,
+      stderr: makeRecorder(),
+    })
+
+    assert.equal(exitCode, 0)
+    assert.match(
+      out.messages.join('\n'),
+      /env sources: \.env\.development\.local, process env/,
+    )
+    assert.match(out.messages.join('\n'), /auth profile: local-demo/)
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -157,69 +270,64 @@ test('runDoctor fails for a wrong Yarn version', async () => {
   }
 })
 
-test('detectAuthProfile uses the app environment profile names', () => {
-  assert.equal(
-    detectAuthProfile({
-      VITE_DEMO_AUTH_ENABLED: 'false',
-      VITE_PUBLIC_BASE_PATH: '/',
-      VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: '',
-      VITE_COGNITO_REDIRECT_SIGN_IN: '',
-      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
-      VITE_USER_POOL_CLIENT_ID: '',
-      VITE_USER_POOL_ID: '',
-    }),
-    'local-disabled',
-  )
-  assert.equal(
-    detectAuthProfile({
-      VITE_DEMO_AUTH_ENABLED: 'true',
-      VITE_PUBLIC_BASE_PATH: '/',
-      VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: '',
-      VITE_COGNITO_REDIRECT_SIGN_IN: '',
-      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
-      VITE_USER_POOL_CLIENT_ID: '',
-      VITE_USER_POOL_ID: '',
-    }),
-    'local-demo',
-  )
-  assert.equal(
-    detectAuthProfile({
-      VITE_DEMO_AUTH_ENABLED: 'true',
-      VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
-      VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: '',
-      VITE_COGNITO_REDIRECT_SIGN_IN: '',
-      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
-      VITE_USER_POOL_CLIENT_ID: '',
-      VITE_USER_POOL_ID: '',
-    }),
-    'pages-demo',
-  )
-  assert.equal(
-    detectAuthProfile({
-      VITE_DEMO_AUTH_ENABLED: 'false',
-      VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
-      VITE_COGNITO_REDIRECT_SIGN_IN: 'http://localhost:3000/signin',
-      VITE_COGNITO_REDIRECT_SIGN_OUT: 'http://localhost:3000/signout',
-      VITE_USER_POOL_CLIENT_ID: 'client-id',
-      VITE_USER_POOL_ID: 'us-east-1_abcd1234',
-    }),
-    'cognito',
-  )
-  assert.equal(
-    detectAuthProfile({
-      VITE_DEMO_AUTH_ENABLED: 'true',
-      VITE_PUBLIC_BASE_PATH: '/',
-      VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
-      VITE_COGNITO_REDIRECT_SIGN_IN: '',
-      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
-      VITE_USER_POOL_CLIENT_ID: '',
-      VITE_USER_POOL_ID: '',
-    }),
-    'unknown',
-  )
+test('detectAuthProfile matches representative appConfig runtime profiles', () => {
+  const profileCases = [
+    {
+      name: 'local-disabled',
+      env: {
+        ...blankCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'false',
+        VITE_PUBLIC_BASE_PATH: '/',
+      },
+      profile: 'local-disabled',
+    },
+    {
+      name: 'local-demo',
+      env: {
+        ...blankCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'true',
+        VITE_PUBLIC_BASE_PATH: '/',
+      },
+      profile: 'local-demo',
+    },
+    {
+      name: 'pages-demo',
+      env: {
+        ...blankCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'true',
+        VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
+      },
+      profile: 'pages-demo',
+    },
+    {
+      name: 'cognito',
+      env: {
+        ...validCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'false',
+      },
+      profile: 'cognito',
+    },
+    {
+      name: 'cognito overrides requested demo auth',
+      env: {
+        ...validCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'true',
+      },
+      profile: 'cognito',
+    },
+    {
+      name: 'unknown',
+      env: {
+        ...blankCognitoEnv,
+        VITE_DEMO_AUTH_ENABLED: 'true',
+        VITE_PUBLIC_BASE_PATH: '/',
+        VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
+      },
+      profile: 'unknown',
+    },
+  ]
+
+  for (const { name, env, profile } of profileCases) {
+    assert.equal(detectAuthProfile(env), profile, name)
+  }
 })

--- a/scripts/setup-doctor.test.mjs
+++ b/scripts/setup-doctor.test.mjs
@@ -157,10 +157,11 @@ test('runDoctor fails for a wrong Yarn version', async () => {
   }
 })
 
-test('detectAuthProfile distinguishes disabled, demo, and Cognito profiles', () => {
+test('detectAuthProfile uses the app environment profile names', () => {
   assert.equal(
     detectAuthProfile({
       VITE_DEMO_AUTH_ENABLED: 'false',
+      VITE_PUBLIC_BASE_PATH: '/',
       VITE_AWS_REGION: '',
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
@@ -168,11 +169,12 @@ test('detectAuthProfile distinguishes disabled, demo, and Cognito profiles', () 
       VITE_USER_POOL_CLIENT_ID: '',
       VITE_USER_POOL_ID: '',
     }),
-    'disabled',
+    'local-disabled',
   )
   assert.equal(
     detectAuthProfile({
       VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_PUBLIC_BASE_PATH: '/',
       VITE_AWS_REGION: '',
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
@@ -180,7 +182,20 @@ test('detectAuthProfile distinguishes disabled, demo, and Cognito profiles', () 
       VITE_USER_POOL_CLIENT_ID: '',
       VITE_USER_POOL_ID: '',
     }),
-    'demo',
+    'local-demo',
+  )
+  assert.equal(
+    detectAuthProfile({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
+      VITE_AWS_REGION: '',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+    'pages-demo',
   )
   assert.equal(
     detectAuthProfile({
@@ -193,5 +208,18 @@ test('detectAuthProfile distinguishes disabled, demo, and Cognito profiles', () 
       VITE_USER_POOL_ID: 'us-east-1_abcd1234',
     }),
     'cognito',
+  )
+  assert.equal(
+    detectAuthProfile({
+      VITE_DEMO_AUTH_ENABLED: 'true',
+      VITE_PUBLIC_BASE_PATH: '/',
+      VITE_AWS_REGION: 'us-east-1',
+      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_REDIRECT_SIGN_IN: '',
+      VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+      VITE_USER_POOL_CLIENT_ID: '',
+      VITE_USER_POOL_ID: '',
+    }),
+    'unknown',
   )
 })

--- a/scripts/setup-doctor.test.mjs
+++ b/scripts/setup-doctor.test.mjs
@@ -162,7 +162,7 @@ test('detectAuthProfile uses the app environment profile names', () => {
     detectAuthProfile({
       VITE_DEMO_AUTH_ENABLED: 'false',
       VITE_PUBLIC_BASE_PATH: '/',
-      VITE_AWS_REGION: '',
+      VITE_AWS_REGION: 'us-east-1',
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
       VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -175,7 +175,7 @@ test('detectAuthProfile uses the app environment profile names', () => {
     detectAuthProfile({
       VITE_DEMO_AUTH_ENABLED: 'true',
       VITE_PUBLIC_BASE_PATH: '/',
-      VITE_AWS_REGION: '',
+      VITE_AWS_REGION: 'us-east-1',
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
       VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -188,7 +188,7 @@ test('detectAuthProfile uses the app environment profile names', () => {
     detectAuthProfile({
       VITE_DEMO_AUTH_ENABLED: 'true',
       VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
-      VITE_AWS_REGION: '',
+      VITE_AWS_REGION: 'us-east-1',
       VITE_COGNITO_DOMAIN: '',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
       VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -214,7 +214,7 @@ test('detectAuthProfile uses the app environment profile names', () => {
       VITE_DEMO_AUTH_ENABLED: 'true',
       VITE_PUBLIC_BASE_PATH: '/',
       VITE_AWS_REGION: 'us-east-1',
-      VITE_COGNITO_DOMAIN: '',
+      VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
       VITE_COGNITO_REDIRECT_SIGN_IN: '',
       VITE_COGNITO_REDIRECT_SIGN_OUT: '',
       VITE_USER_POOL_CLIENT_ID: '',

--- a/scripts/setup-entrypoint.test.mjs
+++ b/scripts/setup-entrypoint.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+
+const execFileAsync = promisify(execFile)
+
+const requiredUserAgent = 'yarn/4.14.1 npm/? node/v24.15.0 darwin arm64'
+
+const makeEntrypointFixture = async () => {
+  const cwd = await mkdtemp(
+    path.join(await realpath(tmpdir()), 'template vite react-'),
+  )
+  const scriptsDir = path.join(cwd, 'scripts')
+
+  await mkdir(scriptsDir)
+  await copyFile('scripts/setup.mjs', path.join(scriptsDir, 'setup.mjs'))
+  await copyFile(
+    'scripts/setup-doctor-core.mjs',
+    path.join(scriptsDir, 'setup-doctor-core.mjs'),
+  )
+  await writeFile(
+    path.join(cwd, '.env.example'),
+    "VITE_DEMO_AUTH_ENABLED='false'\nVITE_IDP_ENABLED='false'\n",
+  )
+
+  return cwd
+}
+
+test('setup CLI entrypoint runs from paths containing spaces', async () => {
+  const cwd = await makeEntrypointFixture()
+  const envPath = path.join(cwd, '.env.development.local')
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [path.join(cwd, 'scripts/setup.mjs')],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          npm_config_user_agent: requiredUserAgent,
+        },
+      },
+    )
+
+    assert.equal(
+      await readFile(envPath, 'utf8'),
+      "VITE_DEMO_AUTH_ENABLED='false'\nVITE_IDP_ENABLED='false'\n",
+    )
+
+    await writeFile(envPath, 'LOCAL_ONLY=true\n')
+    await execFileAsync(
+      process.execPath,
+      [path.join(cwd, 'scripts/setup.mjs')],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          npm_config_user_agent: requiredUserAgent,
+        },
+      },
+    )
+
+    assert.equal(await readFile(envPath, 'utf8'), 'LOCAL_ONLY=true\n')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 import {
   commandRunner,
@@ -60,6 +61,6 @@ export const runSetup = async ({
   return 0
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   process.exitCode = await runSetup()
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import process from 'node:process'
+
+import {
+  commandRunner,
+  ensureLocalEnv,
+  printRuntimeErrors,
+  checkRuntime,
+  ENV_LOCAL_FILE,
+  writer,
+} from './setup-doctor-core.mjs'
+
+export const runSetup = async ({
+  cwd = process.cwd(),
+  env = process.env,
+  nodeVersion = process.versions.node,
+  runCommand = commandRunner,
+  stdout = writer(process.stdout),
+  stderr = writer(process.stderr),
+} = {}) => {
+  const runtime = checkRuntime({ cwd, env, nodeVersion, runCommand })
+
+  if (!runtime.ok) {
+    printRuntimeErrors(runtime, stderr)
+    return 1
+  }
+
+  try {
+    const envStatus = await ensureLocalEnv(cwd)
+
+    if (envStatus === 'created') {
+      stdout.write(`Created ${ENV_LOCAL_FILE} from .env.example.`)
+    } else {
+      stdout.write(`${ENV_LOCAL_FILE} already exists; leaving it unchanged.`)
+    }
+  } catch (error) {
+    stderr.write(
+      `Error: could not prepare ${ENV_LOCAL_FILE}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    return 1
+  }
+
+  const prepare = runCommand('yarn', ['prepare'], { cwd })
+
+  if (prepare.status !== 0) {
+    stderr.write(
+      'Warning: Husky setup could not run with `yarn prepare`. Runtime checks passed, so setup will continue.',
+    )
+
+    if (prepare.stderr) {
+      stderr.write(prepare.stderr.trim())
+    }
+
+    return 0
+  }
+
+  stdout.write('Husky hooks prepared with `yarn prepare`.')
+  return 0
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await runSetup()
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,21 @@ export type AppFeatureFlags = {
   IDP_ENABLED: boolean
 }
 
+export type AppEnvironmentProfile =
+  | 'local-disabled'
+  | 'local-demo'
+  | 'cognito'
+  | 'pages-demo'
+  | 'unknown'
+
+export type AppConfigProfileResult = {
+  profile: AppEnvironmentProfile
+  authEnabled: boolean
+  cognitoAuthEnabled: boolean
+  demoAuthEnabled: boolean
+  warnings: string[]
+}
+
 export type FormField = {
   name: string
   label?: string

--- a/src/utils/appConfig.test.ts
+++ b/src/utils/appConfig.test.ts
@@ -33,7 +33,7 @@ test('returns the local demo profile when demo auth is requested and Cognito con
   const result = getAppConfigProfile({
     VITE_DEMO_AUTH_ENABLED: 'true',
     VITE_PUBLIC_BASE_PATH: '/',
-    VITE_AWS_REGION: '',
+    VITE_AWS_REGION: 'us-east-1',
     VITE_COGNITO_DOMAIN: '',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -52,7 +52,7 @@ test('returns the pages demo profile for non-root demo builds with blank Cognito
   const result = getAppConfigProfile({
     VITE_DEMO_AUTH_ENABLED: 'true',
     VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
-    VITE_AWS_REGION: '',
+    VITE_AWS_REGION: 'us-east-1',
     VITE_COGNITO_DOMAIN: '',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -71,7 +71,8 @@ test('returns the local disabled profile when Cognito config is blank and demo a
   const result = getAppConfigProfile({
     VITE_DEMO_AUTH_ENABLED: 'false',
     VITE_PUBLIC_BASE_PATH: '/',
-    VITE_AWS_REGION: '',
+    VITE_AWS_REGION: 'us-east-1',
+    VITE_CF_DOMAIN: 'https://localhost:3000',
     VITE_COGNITO_DOMAIN: '',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -92,7 +93,7 @@ test('returns warnings without enabling demo auth when demo auth conflicts with 
   const result = getAppConfigProfile({
     VITE_DEMO_AUTH_ENABLED: 'true',
     VITE_AWS_REGION: 'us-east-1',
-    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
     VITE_USER_POOL_CLIENT_ID: '',
@@ -127,7 +128,7 @@ test('returns Cognito profile with a warning when valid Cognito config overrides
 test('enables demo auth when requested and Cognito config is blank', () => {
   const config = createAppConfig({
     VITE_DEMO_AUTH_ENABLED: 'true',
-    VITE_AWS_REGION: '',
+    VITE_AWS_REGION: 'us-east-1',
     VITE_COGNITO_DOMAIN: '',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -143,7 +144,7 @@ test('enables demo auth when requested and Cognito config is blank', () => {
 test('keeps auth disabled when Cognito and demo auth are both unavailable', () => {
   const config = createAppConfig({
     VITE_DEMO_AUTH_ENABLED: 'false',
-    VITE_AWS_REGION: '',
+    VITE_AWS_REGION: 'us-east-1',
     VITE_COGNITO_DOMAIN: '',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
@@ -182,7 +183,7 @@ test('keeps demo auth disabled when Cognito config is partially set and invalid'
   const config = createAppConfig({
     VITE_DEMO_AUTH_ENABLED: 'true',
     VITE_AWS_REGION: 'us-east-1',
-    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_DOMAIN: 'https://example.auth.us-east-1.amazoncognito.com',
     VITE_COGNITO_REDIRECT_SIGN_IN: '',
     VITE_COGNITO_REDIRECT_SIGN_OUT: '',
     VITE_USER_POOL_CLIENT_ID: '',

--- a/src/utils/appConfig.test.ts
+++ b/src/utils/appConfig.test.ts
@@ -1,4 +1,4 @@
-import { createAppConfig } from '@/utils/appConfig'
+import { createAppConfig, getAppConfigProfile } from '@/utils/appConfig'
 
 const validCognitoEnv = {
   VITE_AWS_REGION: 'us-east-1',
@@ -15,6 +15,113 @@ test('enables real Cognito auth when Cognito config is valid', () => {
   expect(config.COGNITO_AUTH_ENABLED).toBe(true)
   expect(config.DEMO_AUTH_ENABLED).toBe(false)
   expect(config.AUTH_ENABLED).toBe(true)
+})
+
+test('returns the cognito profile when Cognito config is valid', () => {
+  const result = getAppConfigProfile(validCognitoEnv)
+
+  expect(result).toEqual({
+    profile: 'cognito',
+    authEnabled: true,
+    cognitoAuthEnabled: true,
+    demoAuthEnabled: false,
+    warnings: [],
+  })
+})
+
+test('returns the local demo profile when demo auth is requested and Cognito config is blank', () => {
+  const result = getAppConfigProfile({
+    VITE_DEMO_AUTH_ENABLED: 'true',
+    VITE_PUBLIC_BASE_PATH: '/',
+    VITE_AWS_REGION: '',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(result.profile).toBe('local-demo')
+  expect(result.authEnabled).toBe(true)
+  expect(result.cognitoAuthEnabled).toBe(false)
+  expect(result.demoAuthEnabled).toBe(true)
+  expect(result.warnings).toEqual([])
+})
+
+test('returns the pages demo profile for non-root demo builds with blank Cognito config', () => {
+  const result = getAppConfigProfile({
+    VITE_DEMO_AUTH_ENABLED: 'true',
+    VITE_PUBLIC_BASE_PATH: '/template-vite-react/',
+    VITE_AWS_REGION: '',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(result.profile).toBe('pages-demo')
+  expect(result.authEnabled).toBe(true)
+  expect(result.cognitoAuthEnabled).toBe(false)
+  expect(result.demoAuthEnabled).toBe(true)
+  expect(result.warnings).toEqual([])
+})
+
+test('returns the local disabled profile when Cognito config is blank and demo auth is not requested', () => {
+  const result = getAppConfigProfile({
+    VITE_DEMO_AUTH_ENABLED: 'false',
+    VITE_PUBLIC_BASE_PATH: '/',
+    VITE_AWS_REGION: '',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(result).toEqual({
+    profile: 'local-disabled',
+    authEnabled: false,
+    cognitoAuthEnabled: false,
+    demoAuthEnabled: false,
+    warnings: [],
+  })
+})
+
+test('returns warnings without enabling demo auth when demo auth conflicts with partial Cognito config', () => {
+  const result = getAppConfigProfile({
+    VITE_DEMO_AUTH_ENABLED: 'true',
+    VITE_AWS_REGION: 'us-east-1',
+    VITE_COGNITO_DOMAIN: '',
+    VITE_COGNITO_REDIRECT_SIGN_IN: '',
+    VITE_COGNITO_REDIRECT_SIGN_OUT: '',
+    VITE_USER_POOL_CLIENT_ID: '',
+    VITE_USER_POOL_ID: '',
+  })
+
+  expect(result.profile).toBe('unknown')
+  expect(result.authEnabled).toBe(false)
+  expect(result.cognitoAuthEnabled).toBe(false)
+  expect(result.demoAuthEnabled).toBe(false)
+  expect(result.warnings).toEqual([
+    'Demo auth was requested but Cognito environment values are partially configured. Leave all Cognito values blank for demo auth.',
+    'Cognito environment values are partially configured but invalid: Cognito user pool ID is invalid.',
+  ])
+})
+
+test('returns Cognito profile with a warning when valid Cognito config overrides requested demo auth', () => {
+  const result = getAppConfigProfile({
+    ...validCognitoEnv,
+    VITE_DEMO_AUTH_ENABLED: 'true',
+  })
+
+  expect(result.profile).toBe('cognito')
+  expect(result.authEnabled).toBe(true)
+  expect(result.cognitoAuthEnabled).toBe(true)
+  expect(result.demoAuthEnabled).toBe(false)
+  expect(result.warnings).toEqual([
+    'Demo auth was requested but valid Cognito config is present. Cognito auth takes precedence.',
+  ])
 })
 
 test('enables demo auth when requested and Cognito config is blank', () => {
@@ -44,6 +151,17 @@ test('keeps auth disabled when Cognito and demo auth are both unavailable', () =
     VITE_USER_POOL_ID: '',
   })
 
+  expect(config.COGNITO_AUTH_ENABLED).toBe(false)
+  expect(config.DEMO_AUTH_ENABLED).toBe(false)
+  expect(config.AUTH_ENABLED).toBe(false)
+})
+
+test('keeps createAppConfig backward compatible with partial Vite env objects', () => {
+  const config = createAppConfig({
+    VITE_DEMO_AUTH_ENABLED: 'false',
+  })
+
+  expect(config.AWS_REGION).toBe('')
   expect(config.COGNITO_AUTH_ENABLED).toBe(false)
   expect(config.DEMO_AUTH_ENABLED).toBe(false)
   expect(config.AUTH_ENABLED).toBe(false)

--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -1,5 +1,8 @@
-import type { AppConfig } from '@/types'
-import { isCognitoConfigValid } from '@/utils/cognitoConfig'
+import type { AppConfig, AppConfigProfileResult } from '@/types'
+import {
+  getCognitoConfigError,
+  isCognitoConfigValid,
+} from '@/utils/cognitoConfig'
 
 type AppConfigEnv = {
   VITE_AWS_REGION?: string
@@ -12,6 +15,15 @@ type AppConfigEnv = {
   VITE_PUBLIC_BASE_PATH?: string
   VITE_USER_POOL_CLIENT_ID?: string
   VITE_USER_POOL_ID?: string
+}
+
+type AuthConfig = {
+  AWS_REGION: string
+  COGNITO_DOMAIN: string
+  COGNITO_REDIRECT_SIGN_IN: string
+  COGNITO_REDIRECT_SIGN_OUT: string
+  USER_POOL_CLIENT_ID: string
+  USER_POOL_ID: string
 }
 
 export const readBooleanEnv = (value: string | undefined) => value === 'true'
@@ -28,30 +40,121 @@ export const buildApiUrl = (cfDomain: string) => {
   }
 }
 
-const areCognitoConfigValuesBlank = (authConfig: {
-  AWS_REGION: string
-  COGNITO_DOMAIN: string
-  COGNITO_REDIRECT_SIGN_IN: string
-  COGNITO_REDIRECT_SIGN_OUT: string
-  USER_POOL_CLIENT_ID: string
-  USER_POOL_ID: string
-}) => Object.values(authConfig).every((value) => value.trim() === '')
+const areCognitoConfigValuesBlank = (authConfig: AuthConfig) =>
+  Object.values(authConfig).every((value) => value.trim() === '')
+
+const areCognitoConfigValuesPartiallySet = (authConfig: AuthConfig) =>
+  !areCognitoConfigValuesBlank(authConfig) && !isCognitoConfigValid(authConfig)
+
+const isAppConfig = (
+  configOrEnv: AppConfigEnv | AppConfig,
+): configOrEnv is AppConfig => 'AUTH_ENABLED' in configOrEnv
+
+const getAuthConfig = (configOrEnv: AppConfigEnv | AppConfig): AuthConfig => ({
+  AWS_REGION: isAppConfig(configOrEnv)
+    ? configOrEnv.AWS_REGION
+    : (configOrEnv.VITE_AWS_REGION ?? ''),
+  COGNITO_DOMAIN: isAppConfig(configOrEnv)
+    ? configOrEnv.COGNITO_DOMAIN
+    : (configOrEnv.VITE_COGNITO_DOMAIN ?? ''),
+  COGNITO_REDIRECT_SIGN_IN: isAppConfig(configOrEnv)
+    ? configOrEnv.COGNITO_REDIRECT_SIGN_IN
+    : (configOrEnv.VITE_COGNITO_REDIRECT_SIGN_IN ?? ''),
+  COGNITO_REDIRECT_SIGN_OUT: isAppConfig(configOrEnv)
+    ? configOrEnv.COGNITO_REDIRECT_SIGN_OUT
+    : (configOrEnv.VITE_COGNITO_REDIRECT_SIGN_OUT ?? ''),
+  USER_POOL_CLIENT_ID: isAppConfig(configOrEnv)
+    ? configOrEnv.USER_POOL_CLIENT_ID
+    : (configOrEnv.VITE_USER_POOL_CLIENT_ID ?? ''),
+  USER_POOL_ID: isAppConfig(configOrEnv)
+    ? configOrEnv.USER_POOL_ID
+    : (configOrEnv.VITE_USER_POOL_ID ?? ''),
+})
+
+const getPublicBasePath = (configOrEnv: AppConfigEnv | AppConfig) =>
+  isAppConfig(configOrEnv)
+    ? configOrEnv.PUBLIC_BASE_PATH
+    : (configOrEnv.VITE_PUBLIC_BASE_PATH ?? '/')
+
+const getDemoAuthEnv = (configOrEnv: AppConfigEnv | AppConfig) =>
+  isAppConfig(configOrEnv)
+    ? String(configOrEnv.DEMO_AUTH_ENABLED)
+    : configOrEnv.VITE_DEMO_AUTH_ENABLED
+
+export const getAppConfigProfile = (
+  configOrEnv: AppConfigEnv | AppConfig,
+): AppConfigProfileResult => {
+  const authConfig = getAuthConfig(configOrEnv)
+  const publicBasePath = getPublicBasePath(configOrEnv)
+  const demoAuthRequested = readBooleanEnv(getDemoAuthEnv(configOrEnv))
+  const cognitoAuthEnabled = isCognitoConfigValid(authConfig)
+  const cognitoValuesBlank = areCognitoConfigValuesBlank(authConfig)
+  const demoAuthEnabled =
+    !cognitoAuthEnabled && cognitoValuesBlank && demoAuthRequested
+  const warnings: string[] = []
+
+  if (demoAuthRequested && cognitoAuthEnabled) {
+    warnings.push(
+      'Demo auth was requested but valid Cognito config is present. Cognito auth takes precedence.',
+    )
+  }
+
+  if (demoAuthRequested && areCognitoConfigValuesPartiallySet(authConfig)) {
+    warnings.push(
+      'Demo auth was requested but Cognito environment values are partially configured. Leave all Cognito values blank for demo auth.',
+    )
+  }
+
+  const cognitoConfigError = getCognitoConfigError(authConfig)
+  if (!cognitoValuesBlank && !cognitoAuthEnabled && cognitoConfigError) {
+    warnings.push(
+      `Cognito environment values are partially configured but invalid: ${cognitoConfigError}`,
+    )
+  }
+
+  if (cognitoAuthEnabled) {
+    return {
+      profile: 'cognito',
+      authEnabled: true,
+      cognitoAuthEnabled,
+      demoAuthEnabled,
+      warnings,
+    }
+  }
+
+  if (demoAuthEnabled) {
+    return {
+      profile: publicBasePath === '/' ? 'local-demo' : 'pages-demo',
+      authEnabled: true,
+      cognitoAuthEnabled,
+      demoAuthEnabled,
+      warnings,
+    }
+  }
+
+  if (cognitoValuesBlank) {
+    return {
+      profile: 'local-disabled',
+      authEnabled: false,
+      cognitoAuthEnabled,
+      demoAuthEnabled,
+      warnings,
+    }
+  }
+
+  return {
+    profile: 'unknown',
+    authEnabled: false,
+    cognitoAuthEnabled,
+    demoAuthEnabled,
+    warnings,
+  }
+}
 
 export const createAppConfig = (env: AppConfigEnv): AppConfig => {
   const cfDomain = env.VITE_CF_DOMAIN ?? ''
-  const authConfig = {
-    AWS_REGION: env.VITE_AWS_REGION ?? '',
-    COGNITO_DOMAIN: env.VITE_COGNITO_DOMAIN ?? '',
-    COGNITO_REDIRECT_SIGN_IN: env.VITE_COGNITO_REDIRECT_SIGN_IN ?? '',
-    COGNITO_REDIRECT_SIGN_OUT: env.VITE_COGNITO_REDIRECT_SIGN_OUT ?? '',
-    USER_POOL_CLIENT_ID: env.VITE_USER_POOL_CLIENT_ID ?? '',
-    USER_POOL_ID: env.VITE_USER_POOL_ID ?? '',
-  }
-  const cognitoAuthEnabled = isCognitoConfigValid(authConfig)
-  const demoAuthEnabled =
-    !cognitoAuthEnabled &&
-    areCognitoConfigValuesBlank(authConfig) &&
-    readBooleanEnv(env.VITE_DEMO_AUTH_ENABLED)
+  const authConfig = getAuthConfig(env)
+  const profile = getAppConfigProfile(env)
 
   return {
     //* AWS configuration
@@ -66,9 +169,9 @@ export const createAppConfig = (env: AppConfigEnv): AppConfig => {
     USER_POOL_ID: authConfig.USER_POOL_ID,
 
     //* Feature flags
-    AUTH_ENABLED: cognitoAuthEnabled || demoAuthEnabled,
-    COGNITO_AUTH_ENABLED: cognitoAuthEnabled,
-    DEMO_AUTH_ENABLED: demoAuthEnabled,
+    AUTH_ENABLED: profile.authEnabled,
+    COGNITO_AUTH_ENABLED: profile.cognitoAuthEnabled,
+    DEMO_AUTH_ENABLED: profile.demoAuthEnabled,
     IDP_ENABLED: readBooleanEnv(env.VITE_IDP_ENABLED),
   }
 }

--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -40,11 +40,20 @@ export const buildApiUrl = (cfDomain: string) => {
   }
 }
 
-const areCognitoConfigValuesBlank = (authConfig: AuthConfig) =>
-  Object.values(authConfig).every((value) => value.trim() === '')
+const getCognitoSpecificValues = (authConfig: AuthConfig) => [
+  authConfig.COGNITO_DOMAIN,
+  authConfig.COGNITO_REDIRECT_SIGN_IN,
+  authConfig.COGNITO_REDIRECT_SIGN_OUT,
+  authConfig.USER_POOL_CLIENT_ID,
+  authConfig.USER_POOL_ID,
+]
+
+const areCognitoSpecificValuesBlank = (authConfig: AuthConfig) =>
+  getCognitoSpecificValues(authConfig).every((value) => value.trim() === '')
 
 const areCognitoConfigValuesPartiallySet = (authConfig: AuthConfig) =>
-  !areCognitoConfigValuesBlank(authConfig) && !isCognitoConfigValid(authConfig)
+  !areCognitoSpecificValuesBlank(authConfig) &&
+  !isCognitoConfigValid(authConfig)
 
 const isAppConfig = (
   configOrEnv: AppConfigEnv | AppConfig,
@@ -88,7 +97,7 @@ export const getAppConfigProfile = (
   const publicBasePath = getPublicBasePath(configOrEnv)
   const demoAuthRequested = readBooleanEnv(getDemoAuthEnv(configOrEnv))
   const cognitoAuthEnabled = isCognitoConfigValid(authConfig)
-  const cognitoValuesBlank = areCognitoConfigValuesBlank(authConfig)
+  const cognitoValuesBlank = areCognitoSpecificValuesBlank(authConfig)
   const demoAuthEnabled =
     !cognitoAuthEnabled && cognitoValuesBlank && demoAuthRequested
   const warnings: string[] = []


### PR DESCRIPTION
## Summary

Adds adoption tooling for teams copying this template, plus explicit setup and auth-profile checks.

### Added

- `yarn init:template` for deterministic dry-run and write-mode rebranding.
- `yarn setup` and `yarn doctor` for repeatable local setup checks.
- Environment profile detection for `local-disabled`, `local-demo`, `cognito`, and `pages-demo`.

### Changed

- Default env examples now represent local development without auth.
- GitHub Pages builds explicitly opt into demo auth on `main`.
- Setup docs now point to `yarn setup` and `yarn doctor`.

### Deprecated

N/A

### Removed

N/A

### Fixed

- Keeps existing `.env.development.local` files unchanged during setup.
- Aligns doctor output with the app runtime profile names.
- Rebrands GitHub Pages workflow URLs when running `init:template --write`.

## How to test

- `yarn lint`
- `yarn test`
- `yarn build`
- `yarn test:e2e --project=chromium-dev`
- `yarn test:e2e --project=chromium-pages`
- Temp-copy setup with missing and existing `.env.development.local`
- `yarn doctor` for default, local-demo, and pages-demo profiles
- `yarn init:template --help`, dry-run, and temp-copy `--write`
