### PR TITLE
feat: add CRUD starter flow and typed API hooks

### DIFF
--- a/e2e/dev-server.dev.e2e.ts
+++ b/e2e/dev-server.dev.e2e.ts
@@ -59,6 +59,31 @@ test('dev server exposes demo auth mode and reaches the dashboard', async ({
   await expectDashboard(page)
 })
 
+test('dev server supports the local CRUD starter records flow', async ({
+  page,
+}) => {
+  await signInWithDemoAuth(page)
+  await expectDashboard(page)
+
+  await expect(page.getByText('Route map')).toBeVisible()
+  await page.getByRole('button', { name: 'New record' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'Create record' })
+  await dialog.getByRole('textbox', { name: 'Record' }).fill('Policy checklist')
+  await dialog.getByRole('textbox', { name: 'Owner' }).fill('Operations')
+  await dialog.getByRole('textbox', { name: 'Status' }).fill('Draft')
+  await dialog.getByRole('button', { name: 'Create record' }).click()
+
+  await expect(dialog).toBeHidden()
+  await expect(page.getByText('Policy checklist')).toBeVisible()
+  await expect(page.getByText('Operations')).toBeVisible()
+  await expect(page.getByText('Draft')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Delete Policy checklist' }).click()
+
+  await expect(page.getByText('Policy checklist')).toBeHidden()
+})
+
 test('dev server renders the authenticated dashboard on mobile', async ({
   page,
 }) => {

--- a/src/components/crud/CreateForm.test.tsx
+++ b/src/components/crud/CreateForm.test.tsx
@@ -132,3 +132,50 @@ test('submits form data only when all required fields are filled and form is not
     expect(onSubmitMock).toHaveBeenCalledWith(defaultValues)
   })
 })
+
+test('does not submit again while a submission is active', async () => {
+  const user = userEvent.setup()
+  let resolveSubmit: (() => void) | undefined
+  onSubmitMock.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveSubmit = resolve
+      }),
+  )
+
+  const { getByRole } = render(
+    <CreateForm
+      open={true}
+      schema={schema}
+      onClose={() => {}}
+      onSubmit={onSubmitMock}
+      FormProps={{
+        defaultValues,
+        mode: 'onChange',
+      }}
+      submitLabel="Submit"
+    />,
+  )
+
+  const form = getByRole('form')
+  const submitButton = getByRole('button', { name: 'Submit' })
+
+  await waitFor(() => {
+    expect(submitButton).toBeEnabled()
+  })
+
+  await user.click(submitButton)
+
+  await waitFor(() => {
+    expect(submitButton).toBeDisabled()
+  })
+
+  act(() => {
+    fireEvent.submit(form)
+  })
+  expect(onSubmitMock).toHaveBeenCalledTimes(1)
+
+  await act(async () => {
+    resolveSubmit?.()
+  })
+})

--- a/src/components/crud/CreateForm.test.tsx
+++ b/src/components/crud/CreateForm.test.tsx
@@ -1,11 +1,4 @@
-import { useState } from 'react'
-import {
-  act,
-  fireEvent,
-  render,
-  renderHook,
-  waitFor,
-} from '@testing-library/react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TextField from '@mui/material/TextField'
 import CreateForm from '@/components/crud/CreateForm'
@@ -59,7 +52,8 @@ test('renders the form when open is true', async () => {
 })
 
 test('calls onSubmit with form data when form is submitted', async () => {
-  const { getByLabelText, getByText } = render(
+  const user = userEvent.setup()
+  const { getByLabelText, getByRole } = render(
     <CreateForm
       open={true}
       onClose={onCloseMock}
@@ -71,15 +65,19 @@ test('calls onSubmit with form data when form is submitted', async () => {
 
   const nameField = getByLabelText(/Name/)
   const addressField = getByLabelText(/Address/)
-  const submit = getByText('Submit')
+  const form = getByRole('form')
+  const submit = getByRole('button', { name: 'Submit' })
 
-  await act(async () => {
-    fireEvent.input(nameField, { target: { value: 'Vendor 1' } })
-    fireEvent.input(addressField, { target: { value: 'Address 1' } })
-    fireEvent.click(submit)
+  await user.type(nameField, defaultValues.name)
+  await user.type(addressField, defaultValues.address)
+  await waitFor(() => {
+    expect(submit).toBeEnabled()
+  })
+  act(() => {
+    fireEvent.submit(form)
   })
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(onSubmitMock).toHaveBeenCalledWith(defaultValues)
   })
 })
@@ -98,19 +96,13 @@ test('calls onClose when Cancel button is clicked', async () => {
     fireEvent.click(getByText('Cancel'))
   })
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(onCloseMock).toHaveBeenCalledTimes(1)
   })
 })
 
 test('submits form data only when all required fields are filled and form is not disabled', async () => {
-  const {
-    result: {
-      current: [values],
-    },
-  } = renderHook(() => useState(defaultValues))
-
-  const { getByText, getByLabelText, getByRole } = render(
+  const { getByRole } = render(
     <CreateForm
       open={true}
       schema={schema}
@@ -118,7 +110,6 @@ test('submits form data only when all required fields are filled and form is not
       onSubmit={onSubmitMock}
       FormProps={{
         defaultValues,
-        values,
         mode: 'onChange',
       }}
       submitLabel="Submit"
@@ -126,16 +117,9 @@ test('submits form data only when all required fields are filled and form is not
   )
 
   const form = getByRole('form')
-  const nameField = getByLabelText(/Name/)
-  const addressField = getByLabelText(/Address/)
-  const submitButton = getByText('Submit')
+  const submitButton = getByRole('button', { name: 'Submit' })
 
-  act(() => {
-    userEvent.type(nameField, 'Test Name')
-    userEvent.type(addressField, 'Test Address')
-  })
-
-  waitFor(() => {
+  await waitFor(() => {
     expect(submitButton).toBeEnabled()
   })
 
@@ -143,7 +127,7 @@ test('submits form data only when all required fields are filled and form is not
     fireEvent.submit(form)
   })
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(onSubmitMock).toHaveBeenCalledTimes(1)
     expect(onSubmitMock).toHaveBeenCalledWith(defaultValues)
   })

--- a/src/components/crud/CreateForm.test.tsx
+++ b/src/components/crud/CreateForm.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TextField from '@mui/material/TextField'
 import CreateForm from '@/components/crud/CreateForm'
+import { FormField } from '@/types'
 
 const defaultValues = {
   name: 'Vendor 1',
@@ -80,6 +81,32 @@ test('calls onSubmit with form data when form is submitted', async () => {
   await waitFor(() => {
     expect(onSubmitMock).toHaveBeenCalledWith(defaultValues)
   })
+})
+
+test('passes react-hook-form refs to the input element', async () => {
+  const refMock = jest.fn()
+  const refSchema: FormField[] = [
+    {
+      ...schema[0],
+      component: ({ inputRef, ...props }) => {
+        refMock(inputRef)
+
+        return <TextField {...props} inputRef={inputRef} />
+      },
+    },
+  ]
+
+  const { getByLabelText } = render(
+    <CreateForm
+      open={true}
+      onClose={onCloseMock}
+      onSubmit={onSubmitMock}
+      schema={refSchema}
+    />,
+  )
+
+  expect(getByLabelText(/Name/)).toBeInTheDocument()
+  expect(refMock).toHaveBeenCalledWith(expect.any(Function))
 })
 
 test('calls onClose when Cancel button is clicked', async () => {

--- a/src/components/crud/CreateForm.tsx
+++ b/src/components/crud/CreateForm.tsx
@@ -56,7 +56,6 @@ const CreateForm: React.FC<CreateFormProps> = ({
 }): JSX.Element => {
   const {
     control,
-    register,
     handleSubmit,
     formState: { errors = {}, isSubmitting, isValid, isValidating },
   } = useForm<FieldValues>({
@@ -69,10 +68,9 @@ const CreateForm: React.FC<CreateFormProps> = ({
 
   const onSubmit = useCallback(
     (data: unknown) => {
-      if (disabled) return
       onSubmitProp(data)
     },
-    [onSubmitProp, disabled],
+    [onSubmitProp],
   )
 
   const onClose = useCallback(() => {
@@ -93,35 +91,29 @@ const CreateForm: React.FC<CreateFormProps> = ({
       <DialogContent>
         <Box component="form" onSubmit={handleSubmit(onSubmit)} role="form">
           <Stack spacing={4} sx={{ pt: 1 }}>
-            {schema.map(({ component: Component, ...field }) => {
-              // dynamically register the fields
-              const { ref: inputRef, ...inputProps } = register(field.name, {
-                required: 'This field is required',
-              })
-
-              return (
-                <Controller
-                  key={field.name}
-                  name={field.name}
-                  control={control}
-                  rules={{ required: field.required }}
-                  defaultValue={field.value}
-                  render={({ field: _f, fieldState: { error } }) => (
-                    <Component
-                      {...field}
-                      {...inputProps}
-                      inputRef={inputRef}
-                      label={field.label}
-                      required={field.required}
-                      error={!!error}
-                      fullWidth
-                      helperText={error ? error?.message : ' '}
-                      multiline={field.multiline}
-                    />
-                  )}
-                />
-              )
-            })}
+            {schema.map(({ component: Component, ...field }) => (
+              <Controller
+                key={field.name}
+                name={field.name}
+                control={control}
+                rules={{
+                  required: field.required ? 'This field is required' : false,
+                }}
+                defaultValue={field.value ?? ''}
+                render={({ field: controllerField, fieldState: { error } }) => (
+                  <Component
+                    {...field}
+                    {...controllerField}
+                    label={field.label}
+                    required={field.required}
+                    error={!!error}
+                    fullWidth
+                    helperText={error ? error?.message : ' '}
+                    multiline={field.multiline}
+                  />
+                )}
+              />
+            ))}
           </Stack>
           <DialogActions>
             <Button onClick={onClose}>{cancelLabel || 'Cancel'}</Button>
@@ -129,9 +121,6 @@ const CreateForm: React.FC<CreateFormProps> = ({
               disabled={disabled ? true : false}
               variant="contained"
               type="submit"
-              onClick={onSubmit}
-              role="button"
-              aria-label="submit"
             >
               {submitLabel || 'Submit'}
             </Button>

--- a/src/components/crud/CreateForm.tsx
+++ b/src/components/crud/CreateForm.tsx
@@ -15,7 +15,7 @@ import { FormField } from '@/types'
 export interface CreateFormProps {
   open: boolean
   onClose: () => void
-  onSubmit: (data: unknown) => void
+  onSubmit: (data: unknown) => Promise<void> | void
   schema: FormField[]
   DialogProps?: React.ComponentProps<typeof Dialog>
   title?: string
@@ -68,9 +68,11 @@ const CreateForm: React.FC<CreateFormProps> = ({
 
   const onSubmit = useCallback(
     (data: unknown) => {
-      onSubmitProp(data)
+      if (disabled) return
+
+      return onSubmitProp(data)
     },
-    [onSubmitProp],
+    [disabled, onSubmitProp],
   )
 
   const onClose = useCallback(() => {

--- a/src/components/crud/CreateForm.tsx
+++ b/src/components/crud/CreateForm.tsx
@@ -30,7 +30,7 @@ export interface CreateFormProps {
  * @param {boolean} props.open - Whether the form is open or not
  * @param {FormField[]} props.schema - The schema for the form
  * @param {() => void} props.onClose - The function to call when the form is closed
- * @param {(data: unknown) => void} props.onSubmit - The function to call when the form is submitted
+ * @param {(data: unknown) => Promise<void> | void} props.onSubmit - The function to call when the form is submitted
  * @returns {JSX.Element}
  * @example
  * <CreateForm
@@ -102,18 +102,24 @@ const CreateForm: React.FC<CreateFormProps> = ({
                   required: field.required ? 'This field is required' : false,
                 }}
                 defaultValue={field.value ?? ''}
-                render={({ field: controllerField, fieldState: { error } }) => (
-                  <Component
-                    {...field}
-                    {...controllerField}
-                    label={field.label}
-                    required={field.required}
-                    error={!!error}
-                    fullWidth
-                    helperText={error ? error?.message : ' '}
-                    multiline={field.multiline}
-                  />
-                )}
+                render={({
+                  field: { ref, ...controllerField },
+                  fieldState: { error },
+                }) => {
+                  return (
+                    <Component
+                      {...field}
+                      {...controllerField}
+                      inputRef={ref}
+                      label={field.label}
+                      required={field.required}
+                      error={!!error}
+                      fullWidth
+                      helperText={error ? error?.message : ' '}
+                      multiline={field.multiline}
+                    />
+                  )
+                }}
               />
             ))}
           </Stack>

--- a/src/components/crud/List.stories.tsx
+++ b/src/components/crud/List.stories.tsx
@@ -57,7 +57,14 @@ export default {
 } as Meta
 
 export const EmptyList = () => {
-  return <List items={[]} schema={schema} deleteItem={() => {}} />
+  return (
+    <List
+      items={[]}
+      schema={schema}
+      deleteItem={() => {}}
+      emptyLabel="No vendors yet"
+    />
+  )
 }
 
 export const PopulatedList = () => {

--- a/src/components/crud/List.test.tsx
+++ b/src/components/crud/List.test.tsx
@@ -63,14 +63,27 @@ test('deletes an item when delete button is clicked', async () => {
     <List items={items} schema={schema} deleteItem={deleteItemMock} />,
   )
 
-  const deleteButtons = getAllByLabelText('delete')
+  const deleteButtons = getAllByLabelText(/delete/i)
 
-  await act(() => {
+  act(() => {
     fireEvent.click(deleteButtons[0])
   })
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(deleteItemMock).toHaveBeenCalledTimes(1)
     expect(deleteItemMock).toHaveBeenCalledWith(items[0].id)
   })
+})
+
+test('renders a reusable empty state when there are no items', () => {
+  const { getByRole, getByText } = render(
+    <List
+      items={[]}
+      schema={schema}
+      deleteItem={deleteItemMock}
+      emptyLabel="Nothing to show"
+    />,
+  )
+
+  expect(getByRole('status')).toContainElement(getByText('Nothing to show'))
 })

--- a/src/components/crud/List.tsx
+++ b/src/components/crud/List.tsx
@@ -2,20 +2,24 @@
 import * as React from 'react'
 import { DataGrid, GridColDef, GridRowId, GridRowModel } from '@mui/x-data-grid'
 import { FormField } from '@/types'
+import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import DeleteIcon from '@mui/icons-material/Delete'
+import Typography from '@mui/material/Typography'
 import toTitleCase from '@/utils/toTitleCase'
 
 export interface ListProps {
   items: GridRowModel[]
   schema: FormField[]
   deleteItem: (id: string) => void
+  emptyLabel?: string
 }
 
 const List: React.FC<ListProps> = ({
   items,
   schema,
   deleteItem,
+  emptyLabel = 'No records yet',
 }): JSX.Element => {
   const handleDelete = (id: GridRowId) => {
     deleteItem(id as string)
@@ -39,9 +43,12 @@ const List: React.FC<ListProps> = ({
       hideSortIcons: true,
       sortable: false,
       renderCell: (params) => {
+        const rowLabel =
+          typeof params.row.name === 'string' ? params.row.name : params.id
+
         return (
           <IconButton
-            aria-label="delete"
+            aria-label={`Delete ${rowLabel}`}
             color="primary"
             onClick={() => handleDelete(params.id)}
           >
@@ -52,12 +59,36 @@ const List: React.FC<ListProps> = ({
     },
   ]
 
+  const NoRowsOverlay = React.useMemo(
+    () =>
+      function ListNoRowsOverlay() {
+        return (
+          <Box
+            role="status"
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              height: '100%',
+              justifyContent: 'center',
+              p: 3,
+            }}
+          >
+            <Typography color="text.secondary" variant="body2">
+              {emptyLabel}
+            </Typography>
+          </Box>
+        )
+      },
+    [emptyLabel],
+  )
+
   return (
     <DataGrid
       // getRowId={(row: FormField) => row.name}
       rows={items}
       columns={columns}
       pagination
+      slots={{ noRowsOverlay: NoRowsOverlay }}
     />
   )
 }

--- a/src/hooks/useApiMutation.test.ts
+++ b/src/hooks/useApiMutation.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import fetchMock from 'jest-fetch-mock'
 import useApiMutation from '@/hooks/useApiMutation'
@@ -118,4 +119,98 @@ test('aborts an active mutation', async () => {
     await expect(mutation).resolves.toBeUndefined()
   })
   expect(aborted).toBe(true)
+})
+
+test('aborts a mutation started with a caller-provided signal', async () => {
+  let aborted = false
+  const callerController = new AbortController()
+  fetchMock.mockImplementationOnce((_input, init) => {
+    const signal = init?.signal as AbortSignal
+
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        aborted = true
+        reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+      })
+    }) as Promise<Response>
+  })
+
+  const { result } = renderHook(() => useApiMutation('items', { jwtToken }))
+  let mutation: Promise<unknown> | undefined
+
+  act(() => {
+    mutation = result.current.mutate(
+      { name: 'Slow item' },
+      { signal: callerController.signal },
+    )
+  })
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  act(() => {
+    result.current.abort()
+  })
+
+  await act(async () => {
+    await expect(mutation).resolves.toBeUndefined()
+  })
+  expect(aborted).toBe(true)
+})
+
+test('caller-provided signals can abort active mutations', async () => {
+  let aborted = false
+  const callerController = new AbortController()
+  fetchMock.mockImplementationOnce((_input, init) => {
+    const signal = init?.signal as AbortSignal
+
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        aborted = true
+        reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+      })
+    }) as Promise<Response>
+  })
+
+  const { result } = renderHook(() => useApiMutation('items', { jwtToken }))
+  let mutation: Promise<unknown> | undefined
+
+  act(() => {
+    mutation = result.current.mutate(
+      { name: 'Slow item' },
+      { signal: callerController.signal },
+    )
+  })
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  act(() => {
+    callerController.abort()
+  })
+
+  await act(async () => {
+    await expect(mutation).resolves.toBeUndefined()
+  })
+  expect(aborted).toBe(true)
+})
+
+test('updates state when rendered in Strict Mode', async () => {
+  const data = { id: '1' }
+  fetchMock.mockResponseOnce(JSON.stringify(data))
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.StrictMode, null, children)
+  const { result } = renderHook(
+    () => useApiMutation<typeof data, { name: string }>('items', { jwtToken }),
+    { wrapper },
+  )
+
+  await act(async () => {
+    await expect(result.current.mutate({ name: 'Item' })).resolves.toEqual(data)
+  })
+
+  expect(result.current.data).toEqual(data)
 })

--- a/src/hooks/useApiMutation.test.ts
+++ b/src/hooks/useApiMutation.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import fetchMock from 'jest-fetch-mock'
+import useApiMutation from '@/hooks/useApiMutation'
+import { ApiRequestError } from '@/utils/apiRequest'
+
+const jwtToken = 'test-token'
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+test('mutates typed data with a request body', async () => {
+  const body = { name: 'New item' }
+  const data = { id: '1', name: 'New item' }
+  fetchMock.mockResponseOnce(JSON.stringify(data))
+
+  const { result } = renderHook(() =>
+    useApiMutation<typeof data, typeof body>('items', { jwtToken }),
+  )
+
+  await act(async () => {
+    await expect(result.current.mutate(body)).resolves.toEqual(data)
+  })
+
+  expect(result.current.data).toEqual(data)
+  expect(result.current.error).toBeNull()
+  expect(result.current.loading).toBe(false)
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('/v1/items'),
+    expect.objectContaining({
+      body: JSON.stringify(body),
+      method: 'POST',
+    }),
+  )
+})
+
+test('stores and rethrows normalized mutation errors', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ error: 'Invalid item' }), {
+    status: 422,
+    statusText: 'Unprocessable Entity',
+  })
+
+  const { result } = renderHook(() =>
+    useApiMutation('items', { jwtToken, method: 'PATCH' }),
+  )
+  let caughtError: unknown
+
+  await act(async () => {
+    try {
+      await result.current.mutate({ name: '' })
+    } catch (error) {
+      caughtError = error
+    }
+  })
+
+  expect(caughtError).toBeInstanceOf(ApiRequestError)
+  expect(result.current.error).toMatchObject({
+    message: 'Invalid item',
+    status: 422,
+  })
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('/v1/items'),
+    expect.objectContaining({
+      method: 'PATCH',
+    }),
+  )
+})
+
+test('resets mutation state', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  const { result } = renderHook(() => useApiMutation('items', { jwtToken }))
+
+  await act(async () => {
+    await result.current.mutate({ name: 'Item' })
+  })
+
+  expect(result.current.data).toEqual({ ok: true })
+
+  act(() => {
+    result.current.reset()
+  })
+
+  expect(result.current.data).toBeNull()
+  expect(result.current.error).toBeNull()
+  expect(result.current.loading).toBe(false)
+})
+
+test('aborts an active mutation', async () => {
+  let aborted = false
+  fetchMock.mockImplementationOnce((_input, init) => {
+    const signal = init?.signal as AbortSignal
+
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        aborted = true
+        reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+      })
+    }) as Promise<Response>
+  })
+
+  const { result } = renderHook(() => useApiMutation('items', { jwtToken }))
+  let mutation: Promise<unknown> | undefined
+
+  act(() => {
+    mutation = result.current.mutate({ name: 'Slow item' })
+  })
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  act(() => {
+    result.current.abort()
+  })
+
+  await act(async () => {
+    await expect(mutation).resolves.toBeUndefined()
+  })
+  expect(aborted).toBe(true)
+})

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -33,6 +33,22 @@ export type UseApiMutationResult<TData = unknown, TBody = unknown> = {
   reset: () => void
 }
 
+const composeAbortSignals = (
+  controller: AbortController,
+  signal?: AbortSignal,
+) => {
+  if (!signal) return controller.signal
+
+  if (signal.aborted) {
+    controller.abort()
+    return controller.signal
+  }
+
+  signal.addEventListener('abort', () => controller.abort(), { once: true })
+
+  return controller.signal
+}
+
 const useApiMutation = <TData = unknown, TBody = unknown>(
   path: string,
   { getToken, headers, jwtToken, method = 'POST' }: UseApiMutationOptions = {},
@@ -41,9 +57,16 @@ const useApiMutation = <TData = unknown, TBody = unknown>(
   const [error, setError] = React.useState<ApiRequestError | Error | null>(null)
   const [loading, setLoading] = React.useState(false)
   const controllerRef = React.useRef<AbortController | null>(null)
-  const mountedRef = React.useRef(true)
+  const mountedRef = React.useRef(false)
+  const optionsRef = React.useRef({ getToken, headers, jwtToken, method, path })
 
   React.useEffect(() => {
+    optionsRef.current = { getToken, headers, jwtToken, method, path }
+  }, [getToken, headers, jwtToken, method, path])
+
+  React.useEffect(() => {
+    mountedRef.current = true
+
     return () => {
       mountedRef.current = false
       controllerRef.current?.abort()
@@ -73,6 +96,7 @@ const useApiMutation = <TData = unknown, TBody = unknown>(
       setError(null)
 
       try {
+        const { getToken, headers, jwtToken, method, path } = optionsRef.current
         const response = await apiRequest<TData, TBody>({
           body,
           getToken,
@@ -81,7 +105,7 @@ const useApiMutation = <TData = unknown, TBody = unknown>(
           method,
           path,
           ...overrides,
-          signal: overrides.signal ?? controller.signal,
+          signal: composeAbortSignals(controller, overrides.signal),
         })
 
         if (mountedRef.current && !controller.signal.aborted) {
@@ -105,7 +129,7 @@ const useApiMutation = <TData = unknown, TBody = unknown>(
         }
       }
     },
-    [abort, getToken, headers, jwtToken, method, path],
+    [abort],
   )
 
   return {

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -1,0 +1,121 @@
+/**
+ * Typed API mutation hook built on the shared API request client.
+ * @module hooks/useApiMutation
+ */
+import * as React from 'react'
+import apiRequest, {
+  ApiRequestError,
+  ApiRequestMethod,
+  ApiRequestOptions,
+  isApiRequestAbortError,
+} from '@/utils/apiRequest'
+
+export type UseApiMutationOptions = Omit<
+  ApiRequestOptions,
+  'body' | 'method' | 'path' | 'signal'
+> & {
+  method?: ApiRequestMethod
+}
+
+export type UseApiMutationOverrides<TBody = unknown> = Partial<
+  ApiRequestOptions<TBody>
+>
+
+export type UseApiMutationResult<TData = unknown, TBody = unknown> = {
+  abort: () => void
+  data: TData | null
+  error: ApiRequestError | Error | null
+  loading: boolean
+  mutate: (
+    body?: TBody,
+    overrides?: UseApiMutationOverrides<TBody>,
+  ) => Promise<TData | undefined>
+  reset: () => void
+}
+
+const useApiMutation = <TData = unknown, TBody = unknown>(
+  path: string,
+  { getToken, headers, jwtToken, method = 'POST' }: UseApiMutationOptions = {},
+): UseApiMutationResult<TData, TBody> => {
+  const [data, setData] = React.useState<TData | null>(null)
+  const [error, setError] = React.useState<ApiRequestError | Error | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const controllerRef = React.useRef<AbortController | null>(null)
+  const mountedRef = React.useRef(true)
+
+  React.useEffect(() => {
+    return () => {
+      mountedRef.current = false
+      controllerRef.current?.abort()
+    }
+  }, [])
+
+  const abort = React.useCallback(() => {
+    controllerRef.current?.abort()
+  }, [])
+
+  const reset = React.useCallback(() => {
+    abort()
+    setData(null)
+    setError(null)
+    setLoading(false)
+  }, [abort])
+
+  const mutate = React.useCallback(
+    async (
+      body?: TBody,
+      overrides: UseApiMutationOverrides<TBody> = {},
+    ): Promise<TData | undefined> => {
+      abort()
+      const controller = new AbortController()
+      controllerRef.current = controller
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await apiRequest<TData, TBody>({
+          body,
+          getToken,
+          headers,
+          jwtToken,
+          method,
+          path,
+          ...overrides,
+          signal: overrides.signal ?? controller.signal,
+        })
+
+        if (mountedRef.current && !controller.signal.aborted) {
+          setData(response ?? null)
+        }
+
+        return response
+      } catch (caughtError) {
+        if (isApiRequestAbortError(caughtError)) {
+          return undefined
+        }
+
+        if (mountedRef.current) {
+          setError(caughtError as ApiRequestError | Error)
+        }
+
+        throw caughtError
+      } finally {
+        if (mountedRef.current && controllerRef.current === controller) {
+          setLoading(false)
+        }
+      }
+    },
+    [abort, getToken, headers, jwtToken, method, path],
+  )
+
+  return {
+    abort,
+    data,
+    error,
+    loading,
+    mutate,
+    reset,
+  }
+}
+
+export default useApiMutation

--- a/src/hooks/useApiQuery.test.ts
+++ b/src/hooks/useApiQuery.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import fetchMock from 'jest-fetch-mock'
 import useApiQuery from '@/hooks/useApiQuery'
@@ -72,6 +73,65 @@ test('refetches the query', async () => {
   })
 
   expect(result.current.data).toEqual({ value: 'second' })
+})
+
+test('does not refetch when inline option identities change', async () => {
+  const data = { value: 'stable' }
+  const getToken = jest.fn().mockReturnValue(jwtToken)
+  fetchMock.mockResponse(JSON.stringify(data))
+
+  const { rerender, result } = renderHook(() =>
+    useApiQuery<typeof data>('items', {
+      getToken,
+      headers: { 'X-Test': 'yes' },
+    }),
+  )
+
+  await waitFor(() => {
+    expect(result.current.data).toEqual(data)
+  })
+
+  rerender()
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('clears stale state when disabled after a successful query', async () => {
+  const data = { value: 'first' }
+  fetchMock.mockResponseOnce(JSON.stringify(data))
+
+  const { rerender, result } = renderHook(
+    ({ enabled }) => useApiQuery<typeof data>('items', { enabled, jwtToken }),
+    { initialProps: { enabled: true } },
+  )
+
+  await waitFor(() => {
+    expect(result.current.data).toEqual(data)
+  })
+
+  rerender({ enabled: false })
+
+  await waitFor(() => {
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+})
+
+test('updates state when rendered in Strict Mode', async () => {
+  const data = { value: 'strict' }
+  fetchMock.mockResponse(JSON.stringify(data))
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.StrictMode, null, children)
+  const { result } = renderHook(
+    () => useApiQuery<typeof data>('items', { jwtToken }),
+    { wrapper },
+  )
+
+  await waitFor(() => {
+    expect(result.current.data).toEqual(data)
+  })
 })
 
 test('aborts an in-flight query on unmount', async () => {

--- a/src/hooks/useApiQuery.test.ts
+++ b/src/hooks/useApiQuery.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import fetchMock from 'jest-fetch-mock'
+import useApiQuery from '@/hooks/useApiQuery'
+import { ApiRequestError } from '@/utils/apiRequest'
+
+const jwtToken = 'test-token'
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+test('fetches typed data for an API path', async () => {
+  const data = { items: [{ id: '1', name: 'First item' }] }
+  fetchMock.mockResponseOnce(JSON.stringify(data))
+
+  const { result } = renderHook(() =>
+    useApiQuery<typeof data>('items', { jwtToken }),
+  )
+
+  await waitFor(() => {
+    expect(result.current.data).toEqual(data)
+  })
+
+  expect(result.current.error).toBeNull()
+  expect(result.current.loading).toBe(false)
+})
+
+test('does not fetch while disabled', () => {
+  const { result } = renderHook(() =>
+    useApiQuery('items', { enabled: false, jwtToken }),
+  )
+
+  expect(result.current.data).toBeNull()
+  expect(result.current.loading).toBe(false)
+  expect(fetchMock).not.toHaveBeenCalled()
+})
+
+test('stores normalized API errors', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ message: 'Nope' }), {
+    status: 500,
+    statusText: 'Server Error',
+  })
+
+  const { result } = renderHook(() => useApiQuery('items', { jwtToken }))
+
+  await waitFor(() => {
+    expect(result.current.error).toBeInstanceOf(ApiRequestError)
+  })
+
+  expect(result.current.error).toMatchObject({
+    message: 'Nope',
+    status: 500,
+  })
+  expect(result.current.loading).toBe(false)
+})
+
+test('refetches the query', async () => {
+  fetchMock
+    .mockResponseOnce(JSON.stringify({ value: 'first' }))
+    .mockResponseOnce(JSON.stringify({ value: 'second' }))
+
+  const { result } = renderHook(() =>
+    useApiQuery<{ value: string }>('items', { jwtToken }),
+  )
+
+  await waitFor(() => {
+    expect(result.current.data).toEqual({ value: 'first' })
+  })
+
+  await act(async () => {
+    await result.current.refetch()
+  })
+
+  expect(result.current.data).toEqual({ value: 'second' })
+})
+
+test('aborts an in-flight query on unmount', async () => {
+  let aborted = false
+  fetchMock.mockImplementationOnce((_input, init) => {
+    const signal = init?.signal as AbortSignal
+
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        aborted = true
+        reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+      })
+    }) as Promise<Response>
+  })
+
+  const { unmount } = renderHook(() => useApiQuery('items', { jwtToken }))
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  unmount()
+
+  await waitFor(() => {
+    expect(aborted).toBe(true)
+  })
+})

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -38,9 +38,16 @@ const useApiQuery = <TData = unknown>(
   const [error, setError] = React.useState<ApiRequestError | Error | null>(null)
   const [loading, setLoading] = React.useState(false)
   const controllerRef = React.useRef<AbortController | null>(null)
-  const mountedRef = React.useRef(true)
+  const mountedRef = React.useRef(false)
+  const optionsRef = React.useRef({ getToken, headers, initialData, jwtToken })
 
   React.useEffect(() => {
+    optionsRef.current = { getToken, headers, initialData, jwtToken }
+  }, [getToken, headers, initialData, jwtToken])
+
+  React.useEffect(() => {
+    mountedRef.current = true
+
     return () => {
       mountedRef.current = false
       controllerRef.current?.abort()
@@ -50,6 +57,8 @@ const useApiQuery = <TData = unknown>(
   const runQuery = React.useCallback(async () => {
     if (!path || !enabled) {
       controllerRef.current?.abort()
+      setData(optionsRef.current.initialData)
+      setError(null)
       setLoading(false)
       return undefined
     }
@@ -61,6 +70,7 @@ const useApiQuery = <TData = unknown>(
     setError(null)
 
     try {
+      const { getToken, headers, jwtToken } = optionsRef.current
       const response = await apiRequest<TData>({
         getToken,
         headers,
@@ -89,7 +99,7 @@ const useApiQuery = <TData = unknown>(
         setLoading(false)
       }
     }
-  }, [enabled, getToken, headers, jwtToken, path])
+  }, [enabled, path])
 
   React.useEffect(() => {
     let active = true

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,115 @@
+/**
+ * Typed API query hook built on the shared API request client.
+ * @module hooks/useApiQuery
+ */
+import * as React from 'react'
+import apiRequest, {
+  ApiRequestError,
+  ApiRequestOptions,
+  isApiRequestAbortError,
+} from '@/utils/apiRequest'
+
+export type UseApiQueryOptions<TData = unknown> = Omit<
+  ApiRequestOptions,
+  'body' | 'method' | 'path' | 'signal'
+> & {
+  enabled?: boolean
+  initialData?: TData | null
+}
+
+export type UseApiQueryResult<TData = unknown> = {
+  data: TData | null
+  error: ApiRequestError | Error | null
+  loading: boolean
+  refetch: () => Promise<TData | undefined>
+}
+
+const useApiQuery = <TData = unknown>(
+  path: string | null,
+  {
+    enabled = true,
+    getToken,
+    headers,
+    initialData = null,
+    jwtToken,
+  }: UseApiQueryOptions<TData> = {},
+): UseApiQueryResult<TData> => {
+  const [data, setData] = React.useState<TData | null>(initialData)
+  const [error, setError] = React.useState<ApiRequestError | Error | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const controllerRef = React.useRef<AbortController | null>(null)
+  const mountedRef = React.useRef(true)
+
+  React.useEffect(() => {
+    return () => {
+      mountedRef.current = false
+      controllerRef.current?.abort()
+    }
+  }, [])
+
+  const runQuery = React.useCallback(async () => {
+    if (!path || !enabled) {
+      controllerRef.current?.abort()
+      setLoading(false)
+      return undefined
+    }
+
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await apiRequest<TData>({
+        getToken,
+        headers,
+        jwtToken,
+        path,
+        signal: controller.signal,
+      })
+
+      if (mountedRef.current && !controller.signal.aborted) {
+        setData(response ?? null)
+      }
+
+      return response
+    } catch (caughtError) {
+      if (isApiRequestAbortError(caughtError)) {
+        return undefined
+      }
+
+      if (mountedRef.current) {
+        setError(caughtError as ApiRequestError | Error)
+      }
+
+      return undefined
+    } finally {
+      if (mountedRef.current && controllerRef.current === controller) {
+        setLoading(false)
+      }
+    }
+  }, [enabled, getToken, headers, jwtToken, path])
+
+  React.useEffect(() => {
+    let active = true
+
+    void Promise.resolve().then(() => {
+      if (active) void runQuery()
+    })
+
+    return () => {
+      active = false
+      controllerRef.current?.abort()
+    }
+  }, [runQuery])
+
+  return {
+    data,
+    error,
+    loading,
+    refetch: runQuery,
+  }
+}
+
+export default useApiQuery

--- a/src/hooks/useFetch.test.ts
+++ b/src/hooks/useFetch.test.ts
@@ -10,8 +10,27 @@ describe('useFetch', () => {
     fetchMock.resetMocks()
   })
 
-  test('fetches API data successfully through the compatibility wrapper', async () => {
+  test('fetches absolute URLs with the legacy raw fetch behavior', async () => {
     const data = { message: 'Test data' }
+    fetchMock.mockResponseOnce(JSON.stringify(data))
+
+    const { result } = renderHook(() =>
+      useFetch<typeof data>('https://test.com'),
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(data)
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith('https://test.com', {
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  test('fetches API paths through useApiQuery', async () => {
+    const data = { message: 'API data' }
     fetchMock.mockResponseOnce(JSON.stringify(data))
 
     const { result } = renderHook(() =>
@@ -22,11 +41,28 @@ describe('useFetch', () => {
       expect(result.current.data).toEqual(data)
     })
 
-    expect(result.current.loading).toBe(false)
-    expect(result.current.error).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/test-endpoint'),
+      expect.objectContaining({
+        headers: { authorization: jwtToken },
+      }),
+    )
   })
 
-  test('handles fetch errors through the compatibility wrapper', async () => {
+  test('handles absolute URL fetch errors with the legacy error shape', async () => {
+    fetchMock.mockRejectOnce(new Error('Fetch error'))
+
+    const { result } = renderHook(() => useFetch('https://test.com'))
+
+    await waitFor(() => {
+      expect(result.current.error).toEqual(new Error('Fetch error'))
+    })
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+
+  test('handles API path fetch errors through the compatibility wrapper', async () => {
     fetchMock.mockRejectOnce(new Error('Fetch error'))
 
     const { result } = renderHook(() => useFetch('test-endpoint', { jwtToken }))

--- a/src/hooks/useFetch.test.ts
+++ b/src/hooks/useFetch.test.ts
@@ -1,47 +1,45 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import fetchMock from 'jest-fetch-mock'
 import useFetch from '@/hooks/useFetch'
+import { ApiRequestError } from '@/utils/apiRequest'
+
+const jwtToken = 'test-token'
 
 describe('useFetch', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
   })
 
-  test('fetches data successfully', () => {
+  test('fetches API data successfully through the compatibility wrapper', async () => {
     const data = { message: 'Test data' }
     fetchMock.mockResponseOnce(JSON.stringify(data))
 
-    const { result, rerender } = renderHook(() => useFetch('https://test.com'))
+    const { result } = renderHook(() =>
+      useFetch<typeof data>('test-endpoint', { jwtToken }),
+    )
 
-    waitFor(() => {
-      expect(result.current.loading).toBe(true)
-    })
-
-    rerender()
-
-    waitFor(() => {
-      expect(result.current.loading).toBe(false)
+    await waitFor(() => {
       expect(result.current.data).toEqual(data)
-      expect(result.current.error).toBeNull()
     })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
   })
 
-  test('handles fetch error', () => {
-    const errorMessage = 'Fetch error'
-    fetchMock.mockRejectOnce(new Error(errorMessage))
+  test('handles fetch errors through the compatibility wrapper', async () => {
+    fetchMock.mockRejectOnce(new Error('Fetch error'))
 
-    const { result, rerender } = renderHook(() => useFetch('https://test.com'))
+    const { result } = renderHook(() => useFetch('test-endpoint', { jwtToken }))
 
-    waitFor(() => {
-      expect(result.current.loading).toBe(true)
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(ApiRequestError)
     })
 
-    rerender()
-
-    waitFor(() => {
-      expect(result.current.loading).toBe(false)
-      expect(result.current.data).toBeNull()
-      expect(result.current.error).toEqual(new Error(errorMessage))
+    expect(result.current.data).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toMatchObject({
+      message: 'Request failed before receiving a response',
+      statusText: 'Network Error',
     })
   })
 })

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,17 +1,106 @@
 /**
- * Compatibility wrapper for API-backed fetches.
+ * Compatibility wrapper for legacy URL fetches and API-backed queries.
  * @module hooks/useFetch
  */
+import * as React from 'react'
 import useApiQuery, {
   UseApiQueryOptions,
   UseApiQueryResult,
 } from '@/hooks/useApiQuery'
 
+type UseFetchResult<TData = unknown> = UseApiQueryResult<TData>
+
+const isAbsoluteHttpUrl = (url: string | null) => {
+  return url !== null && /^https?:\/\//i.test(url)
+}
+
+const useRawFetch = <TData = unknown>(
+  url: string | null,
+): UseFetchResult<TData> => {
+  const [data, setData] = React.useState<TData | null>(null)
+  const [error, setError] = React.useState<Error | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const controllerRef = React.useRef<AbortController | null>(null)
+  const mountedRef = React.useRef(false)
+
+  React.useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+      controllerRef.current?.abort()
+    }
+  }, [])
+
+  const refetch = React.useCallback(async () => {
+    if (!url) {
+      controllerRef.current?.abort()
+      setData(null)
+      setError(null)
+      setLoading(false)
+      return undefined
+    }
+
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(url, { signal: controller.signal })
+      const responseData = (await response.json()) as TData
+
+      if (mountedRef.current && !controller.signal.aborted) {
+        setData(responseData)
+      }
+
+      return responseData
+    } catch (caughtError) {
+      if (caughtError instanceof Error && caughtError.name === 'AbortError') {
+        return undefined
+      }
+
+      if (mountedRef.current) {
+        setError(caughtError as Error)
+      }
+
+      return undefined
+    } finally {
+      if (mountedRef.current && controllerRef.current === controller) {
+        setLoading(false)
+      }
+    }
+  }, [url])
+
+  React.useEffect(() => {
+    let active = true
+
+    void Promise.resolve().then(() => {
+      if (active) void refetch()
+    })
+
+    return () => {
+      active = false
+      controllerRef.current?.abort()
+    }
+  }, [refetch])
+
+  return { data, error, loading, refetch }
+}
+
 const useFetch = <TData = unknown>(
-  path: string | null,
+  pathOrUrl: string | null,
   options?: UseApiQueryOptions<TData>,
-): UseApiQueryResult<TData> => {
-  return useApiQuery<TData>(path, options)
+): UseFetchResult<TData> => {
+  const shouldUseRawFetch = isAbsoluteHttpUrl(pathOrUrl)
+  const apiResult = useApiQuery<TData>(
+    shouldUseRawFetch ? null : pathOrUrl,
+    options,
+  )
+  const rawResult = useRawFetch<TData>(shouldUseRawFetch ? pathOrUrl : null)
+
+  return shouldUseRawFetch ? rawResult : apiResult
 }
 
 export default useFetch

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,40 +1,17 @@
 /**
+ * Compatibility wrapper for API-backed fetches.
  * @module hooks/useFetch
  */
-import { useEffect, useState } from 'react'
+import useApiQuery, {
+  UseApiQueryOptions,
+  UseApiQueryResult,
+} from '@/hooks/useApiQuery'
 
-/**
- * Custom hook to fetch data from an API.
- * @param {string} url - URL to fetch
- * @returns {object} - An object containing the data, error, and loading state
- */
-const useFetch = (
-  url: string,
-): {
-  loading: boolean
-  error: Error | null
-  data: unknown
-} => {
-  const [data, setData] = useState(null)
-  const [error, setError] = useState<Error | null>(null)
-  const [loading, setLoading] = useState(false)
-
-  useEffect(() => {
-    ;(async function () {
-      try {
-        setLoading(true)
-        const response = await fetch(url)
-        const data = await response.json()
-        setData(data)
-      } catch (error) {
-        setError(error as Error)
-      } finally {
-        setLoading(false)
-      }
-    })()
-  }, [url])
-
-  return { data, error, loading }
+const useFetch = <TData = unknown>(
+  path: string | null,
+  options?: UseApiQueryOptions<TData>,
+): UseApiQueryResult<TData> => {
+  return useApiQuery<TData>(path, options)
 }
 
 export default useFetch

--- a/src/utils/apiRequest.test.ts
+++ b/src/utils/apiRequest.test.ts
@@ -1,27 +1,41 @@
 import fetchMock from 'jest-fetch-mock'
-import apiRequest from '@/utils/apiRequest'
+import apiRequest, {
+  ApiRequestError,
+  isApiRequestAbortError,
+} from '@/utils/apiRequest'
 import CONFIG from '@/utils/config'
+import getJWT from '@/utils/getJWT'
+
+jest.mock('@/utils/getJWT')
 
 const jwtToken = 'test-token'
 const path = 'test-endpoint'
-const url = new URL(`${CONFIG.API_URL}/v1/${path}`)
+const url = new URL(`${CONFIG.API_URL}/v1/${path}`).toString()
 const headers = {
   authorization: jwtToken,
   'content-type': 'application/json',
 }
 
 beforeEach(() => {
-  jest.resetAllMocks()
+  fetchMock.resetMocks()
+  jest.mocked(getJWT).mockReset()
+  jest.mocked(getJWT).mockResolvedValue(jwtToken)
 })
 
-test('throws an error if no JWT token is provided', async () => {
-  await expect(apiRequest({ jwtToken: '', path: 'test' })).rejects.toThrow(
-    'No JWT token provided',
-  )
+test('parses a successful JSON response body', async () => {
+  const response = { id: '1', name: 'First item' }
+  fetchMock.mockResponseOnce(JSON.stringify(response))
+
+  await expect(
+    apiRequest<typeof response>({ jwtToken, path }),
+  ).resolves.toEqual(response)
 })
 
 test('makes a GET request with the correct URL and headers', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
   await apiRequest({ jwtToken, path })
+
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: null,
     headers,
@@ -30,13 +44,154 @@ test('makes a GET request with the correct URL and headers', async () => {
   })
 })
 
-test('makes a POST request with the correct URL, headers, and body', async () => {
+test('serializes a typed request body', async () => {
   const body = { key: 'value' }
-  await apiRequest({ jwtToken, path, method: 'POST', body })
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest<{ ok: boolean }, typeof body>({
+    jwtToken,
+    path,
+    method: 'POST',
+    body,
+  })
+
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: JSON.stringify(body),
     headers,
     method: 'POST',
     signal: expect.any(AbortSignal),
+  })
+})
+
+test('returns undefined for a 204 response', async () => {
+  fetchMock.mockResponseOnce('', { status: 204 })
+
+  await expect(apiRequest<void>({ jwtToken, path })).resolves.toBeUndefined()
+})
+
+test('returns undefined for an empty response body', async () => {
+  fetchMock.mockResponseOnce('')
+
+  await expect(apiRequest<void>({ jwtToken, path })).resolves.toBeUndefined()
+})
+
+test('normalizes HTTP error responses', async () => {
+  const body = { error: 'Invalid item' }
+  fetchMock.mockResponseOnce(JSON.stringify(body), {
+    status: 422,
+    statusText: 'Unprocessable Entity',
+  })
+  const request = apiRequest({ jwtToken, path })
+
+  await expect(request).rejects.toMatchObject({
+    status: 422,
+    statusText: 'Unprocessable Entity',
+    message: 'Invalid item',
+    path,
+    body,
+  })
+  await expect(request).rejects.toBeInstanceOf(ApiRequestError)
+})
+
+test('normalizes invalid JSON responses', async () => {
+  fetchMock.mockResponseOnce('not-json', {
+    status: 200,
+    statusText: 'OK',
+  })
+
+  await expect(apiRequest({ jwtToken, path })).rejects.toMatchObject({
+    status: 200,
+    statusText: 'OK',
+    message: 'Invalid JSON response',
+    path,
+    body: 'not-json',
+  })
+})
+
+test('uses the existing JWT helper when no explicit token is provided', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ path })
+
+  expect(getJWT).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers,
+    method: 'GET',
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('supports an injected token resolver', async () => {
+  const getToken = jest.fn().mockResolvedValue('resolved-token')
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ path, getToken })
+
+  expect(getToken).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers: {
+      authorization: 'resolved-token',
+      'content-type': 'application/json',
+    },
+    method: 'GET',
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('normalizes token resolution errors', async () => {
+  jest.mocked(getJWT).mockRejectedValueOnce(new Error('missing token'))
+
+  await expect(apiRequest({ path })).rejects.toMatchObject({
+    status: 401,
+    statusText: 'Unauthorized',
+    message: 'Unable to resolve JWT token',
+    path,
+  })
+})
+
+test('passes the abort signal to fetch', async () => {
+  const controller = new AbortController()
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ jwtToken, path, signal: controller.signal })
+
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers,
+    method: 'GET',
+    signal: controller.signal,
+  })
+})
+
+test('normalizes aborted requests', async () => {
+  fetchMock.mockRejectOnce(
+    Object.assign(new Error('Aborted'), {
+      name: 'AbortError',
+    }),
+  )
+
+  const request = apiRequest({ jwtToken, path })
+
+  await expect(request).rejects.toMatchObject({
+    status: 0,
+    statusText: 'AbortError',
+    message: 'Request aborted',
+    path,
+  })
+
+  const error = await request.catch((caughtError) => caughtError)
+  expect(isApiRequestAbortError(error)).toBe(true)
+})
+
+test('normalizes network failures', async () => {
+  fetchMock.mockRejectOnce(new Error('offline'))
+
+  await expect(apiRequest({ jwtToken, path })).rejects.toMatchObject({
+    status: 0,
+    statusText: 'Network Error',
+    message: 'Request failed before receiving a response',
+    path,
   })
 })

--- a/src/utils/apiRequest.test.ts
+++ b/src/utils/apiRequest.test.ts
@@ -177,6 +177,49 @@ test('supports an injected token resolver', async () => {
   })
 })
 
+test('falls back to the JWT helper when the explicit token is empty', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ jwtToken: '', path })
+
+  expect(getJWT).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers: authHeaders,
+    method: 'GET',
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('falls back to the JWT helper when the explicit token is blank', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ jwtToken: '   ', path })
+
+  expect(getJWT).toHaveBeenCalledTimes(1)
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers: authHeaders,
+    method: 'GET',
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('uses a non-empty explicit token before an injected resolver', async () => {
+  const getToken = jest.fn().mockResolvedValue('resolved-token')
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest({ jwtToken, path, getToken })
+
+  expect(getToken).not.toHaveBeenCalled()
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body: null,
+    headers: authHeaders,
+    method: 'GET',
+    signal: expect.any(AbortSignal),
+  })
+})
+
 test('normalizes token resolution errors', async () => {
   jest.mocked(getJWT).mockRejectedValueOnce(new Error('missing token'))
 

--- a/src/utils/apiRequest.test.ts
+++ b/src/utils/apiRequest.test.ts
@@ -11,8 +11,11 @@ jest.mock('@/utils/getJWT')
 const jwtToken = 'test-token'
 const path = 'test-endpoint'
 const url = new URL(`${CONFIG.API_URL}/v1/${path}`).toString()
-const headers = {
+const authHeaders = {
   authorization: jwtToken,
+}
+const jsonHeaders = {
+  ...authHeaders,
   'content-type': 'application/json',
 }
 
@@ -38,7 +41,7 @@ test('makes a GET request with the correct URL and headers', async () => {
 
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: null,
-    headers,
+    headers: authHeaders,
     method: 'GET',
     signal: expect.any(AbortSignal),
   })
@@ -57,7 +60,26 @@ test('serializes a typed request body', async () => {
 
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: JSON.stringify(body),
-    headers,
+    headers: jsonHeaders,
+    method: 'POST',
+    signal: expect.any(AbortSignal),
+  })
+})
+
+test('preserves non-JSON request bodies', async () => {
+  const body = new URLSearchParams({ key: 'value' })
+  fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+
+  await apiRequest<{ ok: boolean }, URLSearchParams>({
+    jwtToken,
+    path,
+    method: 'POST',
+    body,
+  })
+
+  expect(fetchMock).toHaveBeenCalledWith(url, {
+    body,
+    headers: authHeaders,
     method: 'POST',
     signal: expect.any(AbortSignal),
   })
@@ -93,6 +115,22 @@ test('normalizes HTTP error responses', async () => {
   await expect(request).rejects.toBeInstanceOf(ApiRequestError)
 })
 
+test('uses the first non-empty string from common error response fields', async () => {
+  const body = { message: { text: 'ignored' }, error: '', detail: 'Details' }
+  fetchMock.mockResponseOnce(JSON.stringify(body), {
+    status: 400,
+    statusText: 'Bad Request',
+  })
+
+  await expect(apiRequest({ jwtToken, path })).rejects.toMatchObject({
+    status: 400,
+    statusText: 'Bad Request',
+    message: 'Details',
+    path,
+    body,
+  })
+})
+
 test('normalizes invalid JSON responses', async () => {
   fetchMock.mockResponseOnce('not-json', {
     status: 200,
@@ -116,7 +154,7 @@ test('uses the existing JWT helper when no explicit token is provided', async ()
   expect(getJWT).toHaveBeenCalledTimes(1)
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: null,
-    headers,
+    headers: authHeaders,
     method: 'GET',
     signal: expect.any(AbortSignal),
   })
@@ -133,7 +171,6 @@ test('supports an injected token resolver', async () => {
     body: null,
     headers: {
       authorization: 'resolved-token',
-      'content-type': 'application/json',
     },
     method: 'GET',
     signal: expect.any(AbortSignal),
@@ -159,7 +196,7 @@ test('passes the abort signal to fetch', async () => {
 
   expect(fetchMock).toHaveBeenCalledWith(url, {
     body: null,
-    headers,
+    headers: authHeaders,
     method: 'GET',
     signal: controller.signal,
   })
@@ -183,6 +220,7 @@ test('normalizes aborted requests', async () => {
 
   const error = await request.catch((caughtError) => caughtError)
   expect(isApiRequestAbortError(error)).toBe(true)
+  expect(error).toMatchObject({ aborted: true })
 })
 
 test('normalizes network failures', async () => {

--- a/src/utils/apiRequest.ts
+++ b/src/utils/apiRequest.ts
@@ -132,7 +132,9 @@ const resolveToken = async <TBody>({
   path,
 }: Pick<ApiRequestOptions<TBody>, 'getToken' | 'jwtToken' | 'path'>) => {
   try {
-    const token = jwtToken ?? (await (getToken ?? getJWT)())
+    const explicitToken =
+      typeof jwtToken === 'string' && jwtToken.trim() ? jwtToken : undefined
+    const token = explicitToken ?? (await (getToken ?? getJWT)())
 
     if (!token) {
       throw new Error('No JWT token provided')

--- a/src/utils/apiRequest.ts
+++ b/src/utils/apiRequest.ts
@@ -21,6 +21,7 @@ export type ApiRequestOptions<TBody = unknown> = {
 }
 
 type ApiRequestErrorOptions = {
+  aborted?: boolean
   body?: unknown
   cause?: unknown
   message: string
@@ -30,12 +31,14 @@ type ApiRequestErrorOptions = {
 }
 
 export class ApiRequestError extends Error {
+  readonly aborted: boolean
   readonly body?: unknown
   readonly path: string
   readonly status: number
   readonly statusText: string
 
   constructor({
+    aborted = false,
     body,
     cause,
     message,
@@ -45,6 +48,7 @@ export class ApiRequestError extends Error {
   }: ApiRequestErrorOptions) {
     super(message)
     this.name = 'ApiRequestError'
+    this.aborted = aborted
     this.body = body
     this.path = path
     this.status = status
@@ -59,7 +63,7 @@ export class ApiRequestError extends Error {
 export const isApiRequestAbortError = (
   error: unknown,
 ): error is ApiRequestError => {
-  return error instanceof ApiRequestError && error.statusText === 'AbortError'
+  return error instanceof ApiRequestError && error.aborted
 }
 
 const isAbortError = (error: unknown) => {
@@ -72,14 +76,54 @@ const isAbortError = (error: unknown) => {
 const getResponseErrorMessage = (status: number, body: unknown) => {
   if (body && typeof body === 'object') {
     const { detail, error, message } = body as Record<string, unknown>
-    const bodyMessage = message ?? error ?? detail
 
-    if (typeof bodyMessage === 'string' && bodyMessage.trim()) {
-      return bodyMessage
+    for (const bodyMessage of [message, error, detail]) {
+      if (typeof bodyMessage === 'string' && bodyMessage.trim()) {
+        return bodyMessage
+      }
     }
   }
 
   return `Request failed with status ${status}`
+}
+
+const canUseInstanceof = (
+  value: unknown,
+  constructor: typeof Blob | typeof FormData | typeof URLSearchParams,
+) => {
+  return value instanceof constructor
+}
+
+const isBodyInit = (body: unknown): body is BodyInit => {
+  if (typeof body === 'string') return true
+  if (canUseInstanceof(body, Blob)) return true
+  if (canUseInstanceof(body, FormData)) return true
+  if (canUseInstanceof(body, URLSearchParams)) return true
+  if (body instanceof ArrayBuffer) return true
+  if (ArrayBuffer.isView(body)) return true
+
+  return typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
+}
+
+const resolveRequestBody = (body: unknown) => {
+  if (body === undefined) {
+    return {
+      body: null,
+      isJson: false,
+    }
+  }
+
+  if (isBodyInit(body)) {
+    return {
+      body,
+      isJson: false,
+    }
+  }
+
+  return {
+    body: JSON.stringify(body),
+    isJson: true,
+  }
 }
 
 const resolveToken = async <TBody>({
@@ -149,6 +193,7 @@ const fetchResponse = async (
   } catch (cause) {
     if (isAbortError(cause)) {
       throw new ApiRequestError({
+        aborted: true,
         cause,
         message: 'Request aborted',
         path,
@@ -193,11 +238,11 @@ const apiRequest = async <TResponse, TBody = unknown>({
   const headers = new Headers(headersParam)
   headers.set('Authorization', `${token}`)
 
-  if (!headers.has('Content-Type')) {
+  const { body, isJson } = resolveRequestBody(bodyParam)
+
+  if (isJson && !headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json')
   }
-
-  const body = bodyParam === undefined ? null : JSON.stringify(bodyParam)
 
   const response = await fetchResponse(
     url,

--- a/src/utils/apiRequest.ts
+++ b/src/utils/apiRequest.ts
@@ -3,54 +3,230 @@
  * @module utils/apiRequest
  */
 import CONFIG from '@/utils/config'
+import getJWT from '@/utils/getJWT'
 import sanitizeUrl from '@/utils/sanitizeUrl'
+
+export type ApiRequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+export type ApiTokenResolver = () => Promise<string> | string
+
+export type ApiRequestOptions<TBody = unknown> = {
+  body?: TBody
+  getToken?: ApiTokenResolver
+  headers?: HeadersInit
+  jwtToken?: string
+  method?: ApiRequestMethod
+  path: string
+  signal?: AbortSignal
+}
+
+type ApiRequestErrorOptions = {
+  body?: unknown
+  cause?: unknown
+  message: string
+  path: string
+  status: number
+  statusText: string
+}
+
+export class ApiRequestError extends Error {
+  readonly body?: unknown
+  readonly path: string
+  readonly status: number
+  readonly statusText: string
+
+  constructor({
+    body,
+    cause,
+    message,
+    path,
+    status,
+    statusText,
+  }: ApiRequestErrorOptions) {
+    super(message)
+    this.name = 'ApiRequestError'
+    this.body = body
+    this.path = path
+    this.status = status
+    this.statusText = statusText
+
+    if (cause !== undefined) {
+      ;(this as Error & { cause?: unknown }).cause = cause
+    }
+  }
+}
+
+export const isApiRequestAbortError = (
+  error: unknown,
+): error is ApiRequestError => {
+  return error instanceof ApiRequestError && error.statusText === 'AbortError'
+}
+
+const isAbortError = (error: unknown) => {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' || error.message === 'Aborted')
+  )
+}
+
+const getResponseErrorMessage = (status: number, body: unknown) => {
+  if (body && typeof body === 'object') {
+    const { detail, error, message } = body as Record<string, unknown>
+    const bodyMessage = message ?? error ?? detail
+
+    if (typeof bodyMessage === 'string' && bodyMessage.trim()) {
+      return bodyMessage
+    }
+  }
+
+  return `Request failed with status ${status}`
+}
+
+const resolveToken = async <TBody>({
+  getToken,
+  jwtToken,
+  path,
+}: Pick<ApiRequestOptions<TBody>, 'getToken' | 'jwtToken' | 'path'>) => {
+  try {
+    const token = jwtToken ?? (await (getToken ?? getJWT)())
+
+    if (!token) {
+      throw new Error('No JWT token provided')
+    }
+
+    return token
+  } catch (cause) {
+    throw new ApiRequestError({
+      cause,
+      message: 'Unable to resolve JWT token',
+      path,
+      status: 401,
+      statusText: 'Unauthorized',
+    })
+  }
+}
+
+const parseResponseBody = async <TResponse>(
+  response: Response,
+  path: string,
+  strictJson: boolean,
+): Promise<TResponse | string | undefined> => {
+  if (response.status === 204) {
+    return undefined
+  }
+
+  const text = await response.text()
+
+  if (text.trim() === '') {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text) as TResponse
+  } catch (cause) {
+    if (!strictJson) {
+      return text
+    }
+
+    throw new ApiRequestError({
+      body: text,
+      cause,
+      message: 'Invalid JSON response',
+      path,
+      status: response.status,
+      statusText: response.statusText,
+    })
+  }
+}
+
+const fetchResponse = async (
+  url: URL,
+  init: RequestInit,
+  path: string,
+): Promise<Response> => {
+  try {
+    return await fetch(url.toString(), init)
+  } catch (cause) {
+    if (isAbortError(cause)) {
+      throw new ApiRequestError({
+        cause,
+        message: 'Request aborted',
+        path,
+        status: 0,
+        statusText: 'AbortError',
+      })
+    }
+
+    throw new ApiRequestError({
+      cause,
+      message: 'Request failed before receiving a response',
+      path,
+      status: 0,
+      statusText: 'Network Error',
+    })
+  }
+}
 
 /**
  * Make a request to the API.
  * @param {[Object]} body Optional request body.
- * @param {string} jwtToken The Cognito JWT Token.
+ * @param {string} jwtToken Optional explicit Cognito JWT Token.
+ * @param {Function} getToken Optional token resolver, defaults to getJWT.
+ * @param {HeadersInit} headers Optional request headers.
  * @param {[string='GET']} method Optional HTTP method, defaults to 'GET'.
  * @param {string} path The path to the API endpoint.
  * @param {[AbortSignal]} signal Optional AbortSignal to cancel the request.
- * @returns {Promise<Response>} Promise that resolves to the API response.
+ * @returns {Promise<TResponse | undefined>} Parsed JSON response body, or undefined for 204/empty bodies.
  */
-const apiRequest = async ({
+const apiRequest = async <TResponse, TBody = unknown>({
   body: bodyParam,
+  getToken,
+  headers: headersParam,
   jwtToken,
   method = 'GET',
   path,
   signal = new AbortController().signal,
-}: {
-  body?: Record<string, unknown>
-  jwtToken: string
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
-  path: string
-  signal?: AbortSignal
-}): Promise<Response> => {
-  // ensure a jwtToken was provided, otherwise throw an error
-  if (!jwtToken || typeof jwtToken === 'undefined') {
-    throw new Error('No JWT token provided')
-  }
-
-  // create the url object with the path
+}: ApiRequestOptions<TBody>): Promise<TResponse | undefined> => {
+  const token = await resolveToken({ getToken, jwtToken, path })
   const url = sanitizeUrl(`${CONFIG.API_URL}/v1/${path}`)
 
-  // create the headers object
-  const headers = new Headers()
-  headers.append('Authorization', `${jwtToken}`)
-  headers.append('Content-Type', 'application/json')
+  const headers = new Headers(headersParam)
+  headers.set('Authorization', `${token}`)
 
-  const body = bodyParam ? JSON.stringify(bodyParam) : null
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
 
-  // return a promise for the fetch request
-  return fetch(url, {
-    // ensure a body exists and if so, stringify it
-    body,
-    // assign the configured headers to the request
-    headers: Object.fromEntries(headers.entries()),
-    method,
-    signal,
-  })
+  const body = bodyParam === undefined ? null : JSON.stringify(bodyParam)
+
+  const response = await fetchResponse(
+    url,
+    {
+      body,
+      headers: Object.fromEntries(headers.entries()),
+      method,
+      signal,
+    },
+    path,
+  )
+
+  const responseBody = await parseResponseBody<TResponse>(
+    response,
+    path,
+    response.ok,
+  )
+
+  if (!response.ok) {
+    throw new ApiRequestError({
+      body: responseBody,
+      message: getResponseErrorMessage(response.status, responseBody),
+      path,
+      status: response.status,
+      statusText: response.statusText,
+    })
+  }
+
+  return responseBody as TResponse | undefined
 }
 
 export default apiRequest

--- a/src/views/Dashboard/Dashboard.test.tsx
+++ b/src/views/Dashboard/Dashboard.test.tsx
@@ -1,0 +1,63 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DashboardRecords } from './Dashboard'
+
+test('renders seeded dashboard records', () => {
+  render(<DashboardRecords />)
+
+  expect(screen.getByText('Route map')).toBeInTheDocument()
+  expect(screen.getByText('Auth loader')).toBeInTheDocument()
+  expect(screen.getByText('Upload flow')).toBeInTheDocument()
+})
+
+test('creates a dashboard record from the modal form', async () => {
+  const user = userEvent.setup()
+
+  render(<DashboardRecords />)
+
+  await user.click(screen.getByRole('button', { name: /new record/i }))
+  const dialog = screen.getByRole('dialog', { name: /create record/i })
+  await user.type(
+    within(dialog).getByRole('textbox', { name: /^record/i }),
+    'Policy checklist',
+  )
+  await user.type(
+    within(dialog).getByRole('textbox', { name: /^owner/i }),
+    'Operations',
+  )
+  await user.type(
+    within(dialog).getByRole('textbox', { name: /^status/i }),
+    'Draft',
+  )
+  fireEvent.click(
+    within(dialog).getByRole('button', { name: /create record/i }),
+  )
+
+  expect(await screen.findByText('Policy checklist')).toBeInTheDocument()
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})
+
+test('deletes a dashboard record', async () => {
+  const user = userEvent.setup()
+
+  render(<DashboardRecords />)
+
+  const routeMapRow = screen.getByRole('row', { name: /route map/i })
+  await user.click(within(routeMapRow).getByRole('button', { name: /delete/i }))
+
+  await waitFor(() => {
+    expect(screen.queryByText('Route map')).not.toBeInTheDocument()
+  })
+})
+
+test('shows the records empty state when there are no rows', () => {
+  render(<DashboardRecords initialRecords={[]} />)
+
+  expect(screen.getByText('No records yet')).toBeInTheDocument()
+})

--- a/src/views/Dashboard/Dashboard.tsx
+++ b/src/views/Dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import Typography from '@mui/material/Typography'
 import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import DashboardIcon from '@mui/icons-material/Dashboard'
+import CreateForm from '@/components/crud/CreateForm'
 import List from '@/components/crud/List'
 import MultiDropzone from '@/components/MultiDropzone/MultiDropzone'
 import type { UploadedFile } from '@/components/MultiDropzone/types'
@@ -27,6 +28,17 @@ import type { FormField } from '@/types'
 
 export interface DashboardContentProps {
   username?: string
+}
+
+export interface DashboardRecord {
+  id: string
+  name: string
+  owner: string
+  status: string
+}
+
+export interface DashboardRecordsProps {
+  initialRecords?: DashboardRecord[]
 }
 
 const summaryCards = [
@@ -74,23 +86,26 @@ const recordSchema: FormField[] = [
     name: 'name',
     label: 'Record',
     type: 'text',
+    required: true,
     component: TextField,
   },
   {
     name: 'owner',
     label: 'Owner',
     type: 'text',
+    required: true,
     component: TextField,
   },
   {
     name: 'status',
     label: 'Status',
     type: 'text',
+    required: true,
     component: TextField,
   },
 ]
 
-const records = [
+const records: DashboardRecord[] = [
   {
     id: 'route-map',
     name: 'Route map',
@@ -125,6 +140,124 @@ const uploadedFiles: UploadedFile[] = [
 ]
 
 const noop = () => undefined
+
+const normalizeRecordValue = (value: unknown): string => {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+const createRecordId = (name: string, existingRecords: DashboardRecord[]) => {
+  const slug =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'record'
+
+  let candidate = slug
+  let suffix = 2
+  const existingIds = new Set(existingRecords.map(({ id }) => id))
+
+  while (existingIds.has(candidate)) {
+    candidate = `${slug}-${suffix}`
+    suffix += 1
+  }
+
+  return candidate
+}
+
+export const DashboardRecords: React.FC<DashboardRecordsProps> = ({
+  initialRecords = records,
+}): JSX.Element => {
+  const theme = useTheme()
+  const [currentRecords, setCurrentRecords] = React.useState(initialRecords)
+  const [createOpen, setCreateOpen] = React.useState(false)
+
+  const openCreateForm = () => {
+    setCreateOpen(true)
+  }
+
+  const closeCreateForm = () => {
+    setCreateOpen(false)
+  }
+
+  const createRecord = (data: unknown) => {
+    const fields =
+      data && typeof data === 'object' ? (data as Record<string, unknown>) : {}
+    const name = normalizeRecordValue(fields.name)
+    const owner = normalizeRecordValue(fields.owner)
+    const status = normalizeRecordValue(fields.status)
+
+    if (!name || !owner || !status) return
+
+    setCurrentRecords((existingRecords) => [
+      ...existingRecords,
+      {
+        id: createRecordId(name, existingRecords),
+        name,
+        owner,
+        status,
+      },
+    ])
+    closeCreateForm()
+  }
+
+  const deleteRecord = (id: string) => {
+    setCurrentRecords((existingRecords) =>
+      existingRecords.filter((record) => record.id !== id),
+    )
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        border: `1px solid ${theme.palette.divider}`,
+        p: 3,
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          justifyContent: 'space-between',
+          mb: 2,
+        }}
+      >
+        <Box>
+          <Typography variant="h5">Example records</Typography>
+          <Typography variant="body2" color="text.secondary">
+            DataGrid-backed list primitive with seeded template data.
+          </Typography>
+        </Box>
+        <Button
+          onClick={openCreateForm}
+          startIcon={<AddOutlinedIcon />}
+          variant="outlined"
+        >
+          New record
+        </Button>
+      </Stack>
+      <Box sx={{ height: 330 }}>
+        <List
+          items={currentRecords}
+          schema={recordSchema}
+          deleteItem={deleteRecord}
+          emptyLabel="No records yet"
+        />
+      </Box>
+      {createOpen ? (
+        <CreateForm
+          open={createOpen}
+          onClose={closeCreateForm}
+          onSubmit={createRecord}
+          schema={recordSchema}
+          submitLabel="Create record"
+          title="Create record"
+        />
+      ) : null}
+    </Paper>
+  )
+}
 
 export const DashboardContent: React.FC<DashboardContentProps> = ({
   username = '',
@@ -211,36 +344,7 @@ export const DashboardContent: React.FC<DashboardContentProps> = ({
 
       <Grid container spacing={3}>
         <Grid size={{ xs: 12, lg: 8 }}>
-          <Paper
-            elevation={0}
-            sx={{
-              border: `1px solid ${theme.palette.divider}`,
-              p: 3,
-            }}
-          >
-            <Stack
-              direction={{ xs: 'column', sm: 'row' }}
-              spacing={2}
-              sx={{
-                alignItems: { xs: 'flex-start', sm: 'center' },
-                justifyContent: 'space-between',
-                mb: 2,
-              }}
-            >
-              <Box>
-                <Typography variant="h5">Example records</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  DataGrid-backed list primitive with seeded template data.
-                </Typography>
-              </Box>
-              <Button startIcon={<AddOutlinedIcon />} variant="outlined">
-                New record
-              </Button>
-            </Stack>
-            <Box sx={{ height: 330 }}>
-              <List items={records} schema={recordSchema} deleteItem={noop} />
-            </Box>
-          </Paper>
+          <DashboardRecords />
         </Grid>
 
         <Grid size={{ xs: 12, lg: 4 }}>

--- a/src/views/Dashboard/DashboardRecords.stories.tsx
+++ b/src/views/Dashboard/DashboardRecords.stories.tsx
@@ -9,6 +9,12 @@ export default {
   parameters: {
     layout: 'padded',
   },
+  render: (args) => (
+    <DashboardRecords
+      key={JSON.stringify(args.initialRecords ?? 'default')}
+      {...args}
+    />
+  ),
 } as Meta<typeof DashboardRecords>
 
 export const Populated: Story = {}

--- a/src/views/Dashboard/DashboardRecords.stories.tsx
+++ b/src/views/Dashboard/DashboardRecords.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { DashboardRecords } from './Dashboard'
+
+type Story = StoryObj<typeof DashboardRecords>
+
+export default {
+  title: 'Pages/Dashboard/Records',
+  component: DashboardRecords,
+  parameters: {
+    layout: 'padded',
+  },
+} as Meta<typeof DashboardRecords>
+
+export const Populated: Story = {}
+
+export const Empty: Story = {
+  args: {
+    initialRecords: [],
+  },
+}


### PR DESCRIPTION
## Summary

Adds a real local CRUD starter flow to the Dashboard and introduces a typed API client with request hooks.

### Added

- Local create/list/delete records flow on the Dashboard.
- Dashboard records unit tests, Storybook stories, and Playwright dev-server coverage.
- Generic `apiRequest<TResponse, TBody>()` with typed options, JSON parsing, auth token injection, abort support, and normalized `ApiRequestError` failures.
- `useApiQuery` and `useApiMutation` hooks with loading/error/data state and abort cleanup.

### Changed

- `useFetch` now delegates to `useApiQuery` while keeping compatibility behavior.
- CRUD `List` supports empty-state copy and row-specific delete labels.
- `CreateForm` submit handling now uses the form submit path consistently.

### Deprecated

- None.

### Removed

- None.

### Fixed

- The Dashboard "New record" action is no longer inert.

## How to test

- `yarn lint`
- `yarn test`
- `yarn build`
- `yarn build-storybook`
- `yarn test:e2e --project=chromium-dev`
