### PR TITLE
build(deps-dev): upgrade type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@types/lodash": "^4.17.24",
     "@types/node": "24.12.4",
     "@types/prop-types": "^15.7.15",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/react-helmet": "^6.1.11",
     "@types/testing-library__jest-dom": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,12 +5244,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.15":
-  version: 19.2.15
-  resolution: "@types/react@npm:19.2.15"
+"@types/react@npm:^19.2.16":
+  version: 19.2.16
+  resolution: "@types/react@npm:19.2.16"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10/f77447366a94804feea450568f7ebdadc00155457b4c74240972a73601294b09f45cac4e1a28aa97bc01da9ed130bb5fe9a687835d4da6307d457f92530acc3a
+  checksum: 10/b88e77eec8c99757b74539d3495ecd5426e423191fe8c3cdb311f48760046598d9e7c9f876fa6232ee850202205e3165613791ff679e4007d2a92f1512e3b60a
   languageName: node
   linkType: hard
 
@@ -14746,7 +14746,7 @@ __metadata:
     "@types/lodash": "npm:^4.17.24"
     "@types/node": "npm:24.12.4"
     "@types/prop-types": "npm:^15.7.15"
-    "@types/react": "npm:^19.2.15"
+    "@types/react": "npm:^19.2.16"
     "@types/react-dom": "npm:^19.2.3"
     "@types/react-helmet": "npm:^6.1.11"
     "@types/testing-library__jest-dom": "npm:^6.0.0"


### PR DESCRIPTION
## Summary

Upgrade the approved type-only dependency set after the tooling baseline merge.

### Added

None.

### Changed

- Updated `@types/react` to the latest patch release.
- Kept `@types/node` pinned to the Node 24 baseline.
- Refreshed `yarn.lock`.

### Deprecated

None.

### Removed

None.

### Fixed

None.

## How to test

- yarn lint
- yarn test
- yarn build