### PR TITLE
chore: ignore superpowers artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ tmp/
 **/temp/
 **/.cache/
 **/.temp/
+/.superpowers/
+/docs/superpowers/
 
 # macos
 **/.DS_Store


### PR DESCRIPTION
## Summary

Ignore local Superpowers execution artifacts so worker scratch state and generated implementation plans do not appear as untracked repository files.

### Added

- Root-anchored ignore rule for `/.superpowers/`.
- Root-anchored ignore rule for `/docs/superpowers/`.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevents local Superpowers artifacts from polluting `git status` or being committed accidentally.

## How to test

- Run `git check-ignore --no-index -v .superpowers/example.txt docs/superpowers/example.txt` and confirm both paths match `.gitignore`.
- Run `git diff --check origin/main...HEAD`.