### PR TITLE
ci: speed up PR validation

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test_build:
     runs-on: ubuntu-latest
@@ -24,32 +28,14 @@ jobs:
       CI: true
     steps:
       - name: CHECKOUT
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: INSTALL - node.js, yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
-
-      - name: DEBUG - node, npm, yarn versions
-        run: |
-          echo "node --version: $(node --version)"
-          echo "npm --version: $(npm --version)"
-          echo "yarn --version: $(yarn --version)"
-
-      - name: CACHE - get yarn cache folder path
-        id: yarn-cache-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: CACHE - yarn dependencies
-        id: yarn-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: ${{ runner.os }}-yarn-
 
       - name: INSTALL - dependencies
         run: yarn install --immutable
@@ -67,29 +53,41 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: INSTALL - Playwright browser
-        run: yarn test:e2e:install
-
       - name: LINT, UNIT TEST
         run: yarn ci
 
+      - name: BUILD - PR app and Storybook
+        if: github.event_name == 'pull_request'
+        run: yarn run-p build build-storybook
+        env:
+          PAGES_E2E_BASE_PATH: '/template-vite-react/'
+          VITE_AWS_REGION: ''
+          VITE_CF_DOMAIN: 'http://127.0.0.1:4174'
+          VITE_COGNITO_DOMAIN: ''
+          VITE_COGNITO_REDIRECT_SIGN_IN: ''
+          VITE_COGNITO_REDIRECT_SIGN_OUT: ''
+          VITE_DEMO_AUTH_ENABLED: 'true'
+          VITE_IDP_ENABLED: 'false'
+          VITE_PUBLIC_BASE_PATH: '/template-vite-react/'
+          VITE_USER_POOL_CLIENT_ID: ''
+          VITE_USER_POOL_ID: ''
+
+      - name: INSTALL - Playwright browser
+        run: yarn test:e2e:install
+
       - name: E2E TEST
         run: yarn test:e2e
-
-      - name: BUILD
-        run: yarn build
         env:
-          VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
-          VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}
-          VITE_DEMO_AUTH_ENABLED: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
-          VITE_IDP_ENABLED: 'false'
+          PAGES_E2E_BASE_PATH: '/template-vite-react/'
+          PLAYWRIGHT_REUSE_PAGES_BUILD: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
 
-      - name: BUILD - Storybook
-        run: yarn build-storybook
+      - name: BUILD - release app and Storybook
+        if: github.ref == 'refs/heads/main'
+        run: yarn run-p build build-storybook
         env:
-          VITE_PUBLIC_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/template-vite-react/' || '/' }}
-          VITE_CF_DOMAIN: ${{ github.ref == 'refs/heads/main' && 'https://aquia-inc.github.io/template-vite-react/' || '' }}
-          VITE_DEMO_AUTH_ENABLED: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          VITE_PUBLIC_BASE_PATH: '/template-vite-react/'
+          VITE_CF_DOMAIN: 'https://aquia-inc.github.io/template-vite-react/'
+          VITE_DEMO_AUTH_ENABLED: 'true'
           VITE_IDP_ENABLED: 'false'
 
       - name: UPLOAD - build artifact
@@ -109,26 +107,14 @@ jobs:
       pull-requests: write
     steps:
       - name: CHECKOUT
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: INSTALL - node.js, yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
-
-      - name: CACHE - get yarn cache folder path
-        id: yarn-cache-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: CACHE - yarn dependencies
-        id: yarn-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: ${{ runner.os }}-yarn-
 
       - name: INSTALL - dependencies
         run: yarn install --immutable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,11 @@ For shared UI or Storybook changes, also run:
 yarn build-storybook
 ```
 
-CI installs dependencies with `yarn install --immutable`, installs Playwright
-Chromium, runs `yarn ci`, runs `yarn test:e2e`, builds the app, and runs
-semantic-release on pushes to `main`.
+CI installs dependencies and runs quality checks first. On pull requests, it
+builds the app and Storybook concurrently, installs Playwright Chromium, and
+reuses the app build for E2E. Pushes to `main` keep a separate production build
+for semantic-release and GitHub Pages deployment. Local `yarn test:e2e` runs
+continue to build the Pages fixture automatically.
 
 ## Environment And Auth Changes
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ Build Storybook before changing shared UI or stories:
 yarn build-storybook
 ```
 
-CI runs `yarn install --immutable`, installs Playwright Chromium, runs
-`yarn ci`, runs `yarn test:e2e`, builds the app, and runs semantic-release on
-pushes to `main`.
+CI installs dependencies and runs quality checks first. On pull requests, it
+builds the app and Storybook concurrently, installs Playwright Chromium, and
+reuses the app build for E2E. Pushes to `main` keep a separate production build
+for semantic-release and GitHub Pages deployment. Local `yarn test:e2e` runs
+continue to build the Pages fixture automatically.
 
 ## Build, Release, And Deploy
 

--- a/e2e/pages-static-server.mjs
+++ b/e2e/pages-static-server.mjs
@@ -13,6 +13,12 @@ const normalizeBasePath = (value = '/template-vite-react/') => {
     : `${withLeadingSlash}/`
 }
 const basePath = normalizeBasePath(process.env.PAGES_E2E_BASE_PATH)
+const indexFile = join(distDir, 'index.html')
+
+if (!existsSync(indexFile)) {
+  console.error('Missing dist/index.html. Run yarn build before serving Pages.')
+  process.exit(1)
+}
 
 const contentTypes = new Map([
   ['.css', 'text/css; charset=utf-8'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test'
 const devBaseURL = 'http://127.0.0.1:4173'
 const pagesBaseURL = 'http://127.0.0.1:4174'
 const isCI = process.env.CI === 'true'
+const reusePagesBuild = process.env.PLAYWRIGHT_REUSE_PAGES_BUILD === 'true'
 const normalizePagesBasePath = (value = '/template-vite-react/') => {
   const withLeadingSlash = value.startsWith('/') ? value : `/${value}`
 
@@ -62,7 +63,9 @@ const webServer = [
   ...(shouldRunProject('chromium-pages')
     ? [
         {
-          command: 'yarn build && node e2e/pages-static-server.mjs',
+          command: reusePagesBuild
+            ? 'node e2e/pages-static-server.mjs'
+            : 'yarn build && node e2e/pages-static-server.mjs',
           env: {
             ...process.env,
             ...pagesEnv,


### PR DESCRIPTION
## Summary

Reduce pull-request CI wall time while keeping the existing single validation job and all current quality gates. The reference PR job took 2m30s; this Phase 1 change targets an estimated 20–40 second reduction, to be confirmed from the first representative Actions run.

### Added

- Workflow-level concurrency that cancels superseded pull-request runs without cancelling `main` runs.
- Explicit `PLAYWRIGHT_REUSE_PAGES_BUILD` support for serving an existing Pages build during CI.
- A clear error when the Pages static server is started without `dist/index.html`.

### Changed

- Upgrade `actions/checkout` and `actions/setup-node` from v4 to v6.
- Use the Yarn cache managed by `setup-node` and remove the duplicate manual cache.
- Run lint and unit tests before Playwright browser installation.
- Build the PR app and Storybook concurrently, then reuse that app build for E2E.
- Preserve a separate production-configured app and Storybook build on pushes to `main`.
- Update README and contributing guidance to describe the revised CI flow.

### Deprecated

- None.

### Removed

- Redundant Node/Yarn version diagnostics.
- Duplicate `actions/cache` setup for the Yarn cache.
- The second application build on pull requests.

### Fixed

- Superseded PR commits no longer continue consuming CI runners.

## How to test

- `yarn ci` — 72 suites and 295 tests passed.
- Run the app and Storybook builds concurrently with the Pages E2E environment using `yarn run-p build build-storybook`.
- `CI=true PAGES_E2E_BASE_PATH=/template-vite-react/ PLAYWRIGHT_REUSE_PAGES_BUILD=true yarn test:e2e` — 7 tests passed.
- `CI=true yarn test:e2e --project=chromium-pages` — 2 fallback tests passed and the local build behavior remained intact.
- Compare the first representative PR job duration with run `29060911800` after Actions completes.