### PR TITLE
fix: make dashboard drawer responsive

### DIFF
--- a/e2e/dev-server.dev.e2e.ts
+++ b/e2e/dev-server.dev.e2e.ts
@@ -21,6 +21,25 @@ const signInWithDemoAuth = async (page: Page, email = demoEmail) => {
   await page.getByRole('button', { name: 'Sign In' }).click()
 }
 
+const expectDashboardFitsViewport = async (page: Page) => {
+  const layout = await page.getByTestId('app').evaluate((app) => {
+    const main = app.querySelector('main')
+    const mainBounds = main?.getBoundingClientRect()
+
+    return {
+      clientWidth: app.clientWidth,
+      mainLeft: mainBounds?.left,
+      mainRight: mainBounds?.right,
+      scrollWidth: app.scrollWidth,
+      viewportWidth: document.documentElement.clientWidth,
+    }
+  })
+
+  expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth)
+  expect(layout.mainLeft).toBeGreaterThanOrEqual(0)
+  expect(layout.mainRight).toBeLessThanOrEqual(layout.viewportWidth)
+}
+
 test('dev server renders the public home page', async ({ page }) => {
   await page.goto('/')
 
@@ -93,4 +112,22 @@ test('dev server renders the authenticated dashboard on mobile', async ({
 
   await expectDashboard(page, 'mobile')
   await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible()
+
+  const drawer = page.getByTestId('app-drawer')
+
+  await expect(drawer).toHaveAttribute('data-open', 'false')
+  await expect(drawer).toBeHidden()
+  await expectDashboardFitsViewport(page)
+
+  await page.getByRole('button', { name: 'open drawer' }).click()
+
+  await expect(drawer).toHaveAttribute('data-open', 'true')
+  await expect(drawer).toBeVisible()
+  await expectDashboardFitsViewport(page)
+
+  await page.getByRole('button', { name: 'close drawer' }).click()
+
+  await expect(drawer).toHaveAttribute('data-open', 'false')
+  await expect(drawer).toBeHidden()
+  await expectDashboardFitsViewport(page)
 })

--- a/src/components/AppDrawer.tsx
+++ b/src/components/AppDrawer.tsx
@@ -5,9 +5,7 @@ import { styled } from '@mui/material/styles'
 import MuiDrawer, { DrawerProps } from '@mui/material/Drawer'
 import { MuiDrawerWidth } from '@/theme/theme'
 
-const StyledDrawer = styled(MuiDrawer, {
-  shouldForwardProp: (prop) => prop !== 'open',
-})(({ theme, open }) => ({
+const StyledDrawer = styled(MuiDrawer)(({ theme, open }) => ({
   '& .MuiPaper-root': {
     backgroundColor:
       theme.palette.mode === 'light'

--- a/src/layouts/AppLayout/AppLayout.test.tsx
+++ b/src/layouts/AppLayout/AppLayout.test.tsx
@@ -1,7 +1,18 @@
 import { BrowserRouter } from 'react-router-dom'
 import { render, screen, fireEvent } from '@testing-library/react'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import AppLayout from '@/layouts/AppLayout/AppLayout'
 import { DASHBOARD_TITLE } from '@/locales/en'
+
+jest.mock('@mui/material/useMediaQuery')
+
+const mockedUseMediaQuery = useMediaQuery as jest.MockedFunction<
+  typeof useMediaQuery
+>
+
+beforeEach(() => {
+  mockedUseMediaQuery.mockReturnValue(false)
+})
 
 test('renders the main application layout', () => {
   render(<AppLayout />, { wrapper: (props) => <BrowserRouter {...props} /> })
@@ -23,4 +34,54 @@ test('toggles the drawer open and closed', async () => {
 
   fireEvent.click(screen.getByRole('button', { name: /open drawer/i }))
   expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'true')
+})
+
+test('uses a closed temporary drawer without shrinking the app bar on mobile', () => {
+  mockedUseMediaQuery.mockReturnValue(true)
+
+  render(<AppLayout />, {
+    wrapper: (props) => <BrowserRouter {...props} />,
+  })
+
+  const appBar = screen.getByRole('banner')
+  const drawer = screen.getByTestId('app-drawer')
+
+  expect(drawer).toHaveAttribute('data-open', 'false')
+  expect(drawer).not.toHaveClass('MuiDrawer-docked')
+  expect(appBar).toHaveStyle('width: 100%')
+
+  fireEvent.click(screen.getByRole('button', { name: /open drawer/i }))
+
+  expect(drawer).toHaveAttribute('data-open', 'true')
+  expect(appBar).toHaveStyle('width: 100%')
+
+  fireEvent.click(screen.getByTestId('close-drawer-button'))
+  expect(drawer).toHaveAttribute('data-open', 'false')
+})
+
+test('resets the drawer state when crossing the mobile breakpoint', () => {
+  let isMobile = false
+  mockedUseMediaQuery.mockImplementation(() => isMobile)
+
+  const { rerender } = render(<AppLayout />, {
+    wrapper: (props) => <BrowserRouter {...props} />,
+  })
+
+  expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'true')
+
+  fireEvent.click(screen.getByTestId('close-drawer-button'))
+  expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'false')
+
+  isMobile = true
+  rerender(<AppLayout />)
+  expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'false')
+  expect(screen.getByTestId('app-drawer')).not.toHaveClass('MuiDrawer-docked')
+
+  fireEvent.click(screen.getByTestId('open-drawer-button'))
+  expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'true')
+
+  isMobile = false
+  rerender(<AppLayout />)
+  expect(screen.getByTestId('app-drawer')).toHaveAttribute('data-open', 'true')
+  expect(screen.getByTestId('app-drawer')).toHaveClass('MuiDrawer-docked')
 })

--- a/src/layouts/AppLayout/AppLayout.tsx
+++ b/src/layouts/AppLayout/AppLayout.tsx
@@ -12,8 +12,10 @@ import IconButton from '@mui/material/IconButton'
 import List from '@mui/material/List'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import MenuIcon from '@mui/icons-material/Menu'
+import { useTheme } from '@mui/material/styles'
 import AlertMessage from '@/components/AlertMessage'
 import AppBar from '@/components/AppBar'
 import AppDrawer from '@/components/AppDrawer'
@@ -27,11 +29,26 @@ import { DASHBOARD_TITLE } from '@/locales/en'
  * @returns {JSX.Element} The main application layout component.
  */
 const AppLayout: React.FC = (): JSX.Element => {
-  const [drawerOpen, setDrawerOpen] = useState(true)
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  const [drawerState, setDrawerState] = useState({
+    isMobile,
+    open: !isMobile,
+  })
+
+  if (drawerState.isMobile !== isMobile) {
+    setDrawerState({ isMobile, open: !isMobile })
+  }
+
+  const drawerOpen = drawerState.open
 
   const toggleDrawer = useCallback(() => {
-    setDrawerOpen(!drawerOpen)
-  }, [drawerOpen])
+    setDrawerState(({ open }) => ({ isMobile, open: !open }))
+  }, [isMobile])
+
+  const closeDrawer = useCallback(() => {
+    setDrawerState({ isMobile, open: false })
+  }, [isMobile])
 
   return (
     <>
@@ -48,7 +65,11 @@ const AppLayout: React.FC = (): JSX.Element => {
         <AlertMessage />
 
         {/* top nav bar */}
-        <AppBar position="absolute" open={drawerOpen} color="secondary">
+        <AppBar
+          position="absolute"
+          open={drawerOpen && !isMobile}
+          color="secondary"
+        >
           <Toolbar>
             <IconButton
               edge="start"
@@ -82,6 +103,14 @@ const AppLayout: React.FC = (): JSX.Element => {
         {/* menu drawer */}
         <AppDrawer
           open={drawerOpen}
+          variant={isMobile ? 'temporary' : 'permanent'}
+          onClose={closeDrawer}
+          ModalProps={isMobile ? { keepMounted: true } : undefined}
+          sx={
+            isMobile
+              ? { zIndex: (theme) => theme.zIndex.drawer + 2 }
+              : undefined
+          }
           data-open={drawerOpen}
           data-testid="app-drawer"
         >
@@ -94,7 +123,7 @@ const AppLayout: React.FC = (): JSX.Element => {
             }}
           >
             <IconButton
-              onClick={toggleDrawer}
+              onClick={closeDrawer}
               aria-label="close drawer"
               data-testid="close-drawer-button"
               name="close drawer"


### PR DESCRIPTION
## Summary

Fixes #457 by making the authenticated dashboard navigation responsive below the existing `sm` breakpoint.

### Added

- Mobile layout regression coverage for drawer state, viewport width, and horizontal overflow.

### Changed

- Use a temporary overlay drawer below `sm` while preserving the permanent, collapsible desktop drawer.
- Keep the mobile app bar and dashboard content full-width while the drawer is closed or open.

#### Screenshots

**Mobile — drawer closed**

<img width="390" height="844" alt="issue-457-mobile-closed" src="https://github.com/user-attachments/assets/703ae65c-5656-42f2-8f9c-2cc98e2ef6b5" />

**Mobile — temporary drawer open**

<img width="390" height="844" alt="issue-457-mobile-open" src="https://github.com/user-attachments/assets/7fa4554f-a797-40f5-a57f-af25be0f2105" />

**Desktop — permanent drawer unchanged**

<img width="1280" height="800" alt="issue-457-desktop" src="https://github.com/user-attachments/assets/829afb74-09d0-4c9a-9731-0cb941fd5e33" />

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevent the mobile navigation drawer from reserving a collapsed rail or widening the application shell.
- Reset the drawer closed on mobile and open on desktop when crossing the responsive breakpoint.

## How to test

1. Run `yarn test:ci`.
2. Run `yarn test:e2e e2e/dev-server.dev.e2e.ts --project=chromium-dev --grep "authenticated dashboard on mobile"`.
3. Run `yarn lint`.
4. Run `yarn build`.
5. At 390x844, confirm the drawer starts closed, overlays the dashboard when opened, and leaves no horizontal overflow or collapsed rail after closing.
6. At `sm` and wider, confirm the existing permanent drawer and collapse behavior remain unchanged.
