### PR TITLE
ci: bound test and build runtime

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   test_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CI: true
     steps:


### PR DESCRIPTION
## Summary

- add a 15-minute job-level timeout to `test_build` in `.github/workflows/cicd.yaml`
- prevent hung CI test/build jobs from consuming GitHub's much larger default runtime
- leave workflow and job permission scopes unchanged

## Validation

- confirmed exactly one `timeout-minutes: 15` under `jobs.test_build`
- confirmed workflow-level `permissions: contents: read` remains in place
- confirmed write permissions remain scoped under `jobs.release`
- ran `git diff --check`
- parsed the workflow YAML successfully with the documented fallback because `actionlint` is not installed in this environment
