### PR TITLE
chore(github): add epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/EPIC.md
+++ b/.github/ISSUE_TEMPLATE/EPIC.md
@@ -1,0 +1,66 @@
+---
+name: Epic
+about: Coordinate a large initiative across related child issues.
+title: '[Epic] '
+labels: 'enhancement'
+assignees: ''
+---
+
+# Epic summary
+
+<!-- Summarize the initiative and the value it should deliver. -->
+
+## Problem and motivation
+
+<!-- Describe the problem, who it affects, and why it is worth solving now. -->
+
+## Intended outcomes
+
+<!-- List the measurable user, product, or technical outcomes this Epic should produce. -->
+
+## In scope
+
+<!-- List the capabilities and workstreams included in this Epic. -->
+
+## Out of scope
+
+<!-- State related work this Epic intentionally excludes. -->
+
+## Proposed work breakdown
+
+<!-- Outline the major workstreams or phases. Keep implementation details in child issues. -->
+
+## Child-issue tracking checklist
+
+<!--
+Create or link one child issue for each independently deliverable unit of work.
+Add each issue on its own task-list line, for example: - [ ] #123
+Check items as they are completed, and keep each child's detailed acceptance criteria in that issue.
+-->
+
+## Dependencies and sequencing
+
+<!-- Note prerequisites, ordering constraints, external dependencies, and work that can proceed in parallel. -->
+
+## Cross-cutting requirements
+
+<!-- Capture shared accessibility, security, performance, observability, testing, or documentation requirements. -->
+
+## Risks and open questions
+
+<!-- List unresolved decisions, assumptions, delivery risks, and owners when known. -->
+
+## Acceptance criteria
+
+<!--
+Use task-list items for outcomes that prove the Epic as a whole is complete.
+Keep feature-specific or implementation-level acceptance criteria in the relevant child issue.
+-->
+
+## Rollout or migration considerations
+
+<!-- Describe release phases, compatibility needs, data migration, feature flags, communication, and rollback expectations. -->
+
+## Related issues, PRs, designs, and documentation
+
+<!-- Link supporting context and related work that is not already tracked in the child-issue checklist. -->


### PR DESCRIPTION
## Summary

Add a reusable GitHub issue template for coordinating large initiatives across child issues.

### Added

- Epic issue-template defaults for the `[Epic] ` title prefix and `enhancement` label
- Concise planning sections for scope, outcomes, work breakdown, dependencies, risks, rollout, and related context
- Task-list guidance for linking child issues with `#123` references
- Separate guidance for Epic-level and child-issue acceptance criteria

## How to test

- Parse the YAML front matter and verify the expected GitHub issue-template keys and values.
- Confirm all requested Markdown sections are present and ordered.
- Run `yarn doctor`.
- Run `yarn lint`.
- Confirm the existing Bug and Feature issue templates remain unchanged.
