### PR TITLE
fix(ci): isolate non-PR concurrency groups

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

Push-triggered runs currently fall back to `github.ref`, so every run on `main` shares one concurrency group. Because `cancel-in-progress` is disabled for pushes, a newer pending main run can replace an older pending main run.

This changes the fallback to `github.run_id`. Pull request runs continue to group by `github.event.pull_request.number`, while every non-PR run gets a unique group. PR runs still use the existing `cancel-in-progress: true` behavior; non-PR runs remain non-canceling.

## Validation

- `yarn prettier --check .github/workflows/cicd.yaml`
- Ruby YAML parse
- Targeted concurrency assertions for the PR-number/run-ID fallback and PR-only cancellation
- `git diff --check`
- Signed commit verification
