### PR TITLE
fix(docs): document release archive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ semantic-release with conventional commits, writes release notes/changelog
 metadata, creates GitHub releases, and keeps npm publishing disabled. Release
 publishers run one at a time with queued runs preserved. Each release includes
 README and changelog assets plus a version-named `template-vite-react-v*.tar.gz`
-distribution archive with sorted files and normalized tar and gzip metadata.
+distribution archive that expands to a top-level `dist/` directory, with sorted
+files and normalized tar and gzip metadata.
 
 The GitHub Pages deployment job uses the built `dist` artifact after the release
 job succeeds.


### PR DESCRIPTION
## Summary

- clarify that each versioned release archive expands to a top-level `dist/` directory

## Why

- make the extraction layout explicit before the end-to-end v1.6.3 release verification

## Validation

- `yarn install --immutable`
- `yarn prettier --check README.md`
- `git verify-commit HEAD`